### PR TITLE
[SIL-83] Error dialog ui

### DIFF
--- a/.github/workflows/run-code-quality-check.yml
+++ b/.github/workflows/run-code-quality-check.yml
@@ -17,7 +17,11 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-permissions: write-all
+permissions:
+  checks: write
+  contents: write
+  statuses: write
+  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - 'develop'
-      - 'main'
+      - "develop"
+      - "main"
 
 permissions: read-all
 
@@ -25,8 +25,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: "11"
+          distribution: "adopt"
           cache: gradle
 
       - name: Validate Gradle wrapper

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -7,6 +7,8 @@ on:
       - 'develop'
       - 'main'
 
+permissions: read-all
+
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
@@ -1,0 +1,57 @@
+package com.appunite.loudius.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.appunite.loudius.R
+import com.appunite.loudius.ui.theme.LoudiusTheme
+
+@Composable
+fun LoudiusErrorDialog(
+    onConfirmButtonClick: () -> Unit
+) {
+    val openDialog = remember { mutableStateOf(true) }
+    if (openDialog.value) {
+        AlertDialog(
+            onDismissRequest = { openDialog.value = false },
+            title = { Text(text = stringResource(R.string.error_dialog_title)) },
+            text = { Text(text = stringResource(R.string.error_dialog_text)) },
+            confirmButton = {
+                ConfirmButton {
+                    onConfirmButtonClick()
+                }
+            },
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    }
+}
+
+@Composable
+private fun ConfirmButton(
+    confirm: () -> Unit
+) {
+    Button(
+        onClick = { confirm() },
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.tertiary
+        )
+    ) {
+        Text(text = stringResource(R.string.ok))
+    }
+}
+
+@Preview
+@Composable
+fun LoudiusErrorDialogPreview() {
+    LoudiusTheme {
+        LoudiusErrorDialog { }
+    }
+}

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
@@ -16,13 +16,15 @@ import com.appunite.loudius.ui.theme.LoudiusTheme
 @Composable
 fun LoudiusErrorDialog(
     onConfirmButtonClick: () -> Unit,
+    dialogTitle: String,
+    dialogText: String
 ) {
     val openDialog = remember { mutableStateOf(true) }
     if (openDialog.value) {
         AlertDialog(
             onDismissRequest = { openDialog.value = false },
-            title = { Text(text = stringResource(R.string.error_dialog_title)) },
-            text = { Text(text = stringResource(R.string.error_dialog_text)) },
+            title = { Text(text = dialogTitle) },
+            text = { Text(text = dialogText) },
             confirmButton = {
                 ConfirmButton {
                     onConfirmButtonClick()
@@ -52,6 +54,10 @@ private fun ConfirmButton(
 @Composable
 fun LoudiusErrorDialogPreview() {
     LoudiusTheme {
-        LoudiusErrorDialog { }
+        LoudiusErrorDialog(
+            onConfirmButtonClick = { },
+            dialogTitle = "Example title",
+            dialogText = "Example text"
+        )
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
@@ -17,7 +17,7 @@ import com.appunite.loudius.ui.theme.LoudiusTheme
 fun LoudiusErrorDialog(
     onConfirmButtonClick: () -> Unit,
     dialogTitle: String,
-    dialogText: String
+    dialogText: String,
 ) {
     val openDialog = remember { mutableStateOf(true) }
     if (openDialog.value) {
@@ -57,7 +57,7 @@ fun LoudiusErrorDialogPreview() {
         LoudiusErrorDialog(
             onConfirmButtonClick = { },
             dialogTitle = "Example title",
-            dialogText = "Example text"
+            dialogText = "Example text",
         )
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
@@ -15,7 +15,7 @@ import com.appunite.loudius.ui.theme.LoudiusTheme
 
 @Composable
 fun LoudiusErrorDialog(
-    onConfirmButtonClick: () -> Unit
+    onConfirmButtonClick: () -> Unit,
 ) {
     val openDialog = remember { mutableStateOf(true) }
     if (openDialog.value) {
@@ -28,21 +28,21 @@ fun LoudiusErrorDialog(
                     onConfirmButtonClick()
                 }
             },
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surface,
         )
     }
 }
 
 @Composable
 private fun ConfirmButton(
-    confirm: () -> Unit
+    confirm: () -> Unit,
 ) {
     Button(
         onClick = { confirm() },
         colors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.surface,
-            contentColor = MaterialTheme.colorScheme.tertiary
-        )
+            contentColor = MaterialTheme.colorScheme.tertiary,
+        ),
     ) {
         Text(text = stringResource(R.string.ok))
     }

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
@@ -6,8 +6,10 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.appunite.loudius.R
@@ -20,10 +22,10 @@ fun LoudiusErrorDialog(
     dialogText: String = stringResource(id = R.string.error_dialog_text),
     confirmText: String = stringResource(R.string.ok),
 ) {
-    val openDialog = remember { mutableStateOf(true) }
-    if (openDialog.value) {
+    var openDialog by remember { mutableStateOf(true) }
+    if (openDialog) {
         AlertDialog(
-            onDismissRequest = { openDialog.value = false },
+            onDismissRequest = { openDialog = false },
             title = { Text(text = dialogTitle) },
             text = { Text(text = dialogText) },
             confirmButton = {
@@ -43,7 +45,7 @@ private fun ConfirmButton(
     confirm: () -> Unit,
 ) {
     Button(
-        onClick = { confirm() },
+        onClick = confirm,
         colors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.surface,
             contentColor = MaterialTheme.colorScheme.tertiary,

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
@@ -16,8 +16,9 @@ import com.appunite.loudius.ui.theme.LoudiusTheme
 @Composable
 fun LoudiusErrorDialog(
     onConfirmButtonClick: () -> Unit,
-    dialogTitle: String,
-    dialogText: String,
+    dialogTitle: String = stringResource(id = R.string.error_dialog_title),
+    dialogText: String = stringResource(id = R.string.error_dialog_text),
+    confirmText: String = stringResource(R.string.ok)
 ) {
     val openDialog = remember { mutableStateOf(true) }
     if (openDialog.value) {
@@ -26,9 +27,10 @@ fun LoudiusErrorDialog(
             title = { Text(text = dialogTitle) },
             text = { Text(text = dialogText) },
             confirmButton = {
-                ConfirmButton {
-                    onConfirmButtonClick()
-                }
+                ConfirmButton(
+                    confirmText = confirmText,
+                    confirm = onConfirmButtonClick
+                )
             },
             containerColor = MaterialTheme.colorScheme.surface,
         )
@@ -37,6 +39,7 @@ fun LoudiusErrorDialog(
 
 @Composable
 private fun ConfirmButton(
+    confirmText: String,
     confirm: () -> Unit,
 ) {
     Button(
@@ -46,7 +49,7 @@ private fun ConfirmButton(
             contentColor = MaterialTheme.colorScheme.tertiary,
         ),
     ) {
-        Text(text = stringResource(R.string.ok))
+        Text(text = confirmText)
     }
 }
 
@@ -54,10 +57,6 @@ private fun ConfirmButton(
 @Composable
 fun LoudiusErrorDialogPreview() {
     LoudiusTheme {
-        LoudiusErrorDialog(
-            onConfirmButtonClick = { },
-            dialogTitle = "Example title",
-            dialogText = "Example text",
-        )
+        LoudiusErrorDialog(onConfirmButtonClick = {})
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
@@ -18,7 +18,7 @@ fun LoudiusErrorDialog(
     onConfirmButtonClick: () -> Unit,
     dialogTitle: String = stringResource(id = R.string.error_dialog_title),
     dialogText: String = stringResource(id = R.string.error_dialog_text),
-    confirmText: String = stringResource(R.string.ok)
+    confirmText: String = stringResource(R.string.ok),
 ) {
     val openDialog = remember { mutableStateOf(true) }
     if (openDialog.value) {
@@ -29,7 +29,7 @@ fun LoudiusErrorDialog(
             confirmButton = {
                 ConfirmButton(
                     confirmText = confirmText,
-                    confirm = onConfirmButtonClick
+                    confirm = onConfirmButtonClick,
                 )
             },
             containerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
     <string name="details_not_reviewed">Not reviewed for %d h.</string>
     <string name="github_icon">Github icon</string>
     <string name="login_screen">Loudius logo</string>
+    <string name="error_dialog_title">Error</string>
+    <string name="error_dialog_text">Something went wrong…</string>
+    <string name="ok">OK</string>
 </resources>

--- a/github_conf/branch_protection_rules.json
+++ b/github_conf/branch_protection_rules.json
@@ -1,4 +1,0 @@
-{
-    "message": "Not Found",
-    "documentation_url": "https://docs.github.com/rest"
-}


### PR DESCRIPTION
### Description
Added error dialog ui.

### Why?
To be used in the implementation of error handling.

### Demo
![Screenshot 2023-03-06 at 13 18 35](https://user-images.githubusercontent.com/72873966/223108853-876199ed-2027-4f1a-9b38-4c7cb07402c2.png)

### Documentation
- Link to figma: **[Figma](https://www.figma.com/file/yNbcX8VTwufnf7HacYz5Zg/Material-3-Design-Kit-(Community)?node-id=53295%3A27471&t=aoKgGHr8jXK1yCYu-0)**
- Link to task on jira: **[SIL-83](https://silentus-au.atlassian.net/browse/SIL-83)**