### PR TITLE
[SIL-82] FIX - null pointer exception on getting access token. 

### DIFF
--- a/.github/workflows/run-code-quality-check.yml
+++ b/.github/workflows/run-code-quality-check.yml
@@ -17,7 +17,11 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-permissions: write-all
+permissions:
+  checks: write
+  contents: write
+  statuses: write
+  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - 'develop'
-      - 'main'
+      - "develop"
+      - "main"
 
 permissions: read-all
 
@@ -25,8 +25,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: "11"
+          distribution: "adopt"
           cache: gradle
 
       - name: Validate Gradle wrapper

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -7,6 +7,8 @@ on:
       - 'develop'
       - 'main'
 
+permissions: read-all
+
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04

--- a/app/src/main/java/com/appunite/loudius/ui/repos/ReposScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/repos/ReposScreen.kt
@@ -1,9 +1,13 @@
 package com.appunite.loudius.ui.repos
 
 import android.content.Intent
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.hilt.navigation.compose.hiltViewModel
+
 
 @Composable
 fun ReposScreen(
@@ -11,8 +15,14 @@ fun ReposScreen(
     viewModel: ReposViewModel = hiltViewModel(),
 ) {
     val code = intent.data?.getQueryParameter("code")
-    Text(text = code ?: "empty code")
-    code?.let {
-        viewModel.getAccessToken(code)
+    val rememberedCode = rememberUpdatedState(newValue = code)
+    Column {
+        Text(text = code ?: "code is already consumed")
+    }
+    LaunchedEffect(key1 = rememberedCode) {
+        rememberedCode.value?.let {
+            viewModel.getAccessToken(it)
+            intent.data = null
+        }
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/repos/ReposScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/repos/ReposScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.hilt.navigation.compose.hiltViewModel
 
-
 @Composable
 fun ReposScreen(
     intent: Intent,

--- a/github_conf/branch_protection_rules.json
+++ b/github_conf/branch_protection_rules.json
@@ -1,4 +1,0 @@
-{
-    "message": "Not Found",
-    "documentation_url": "https://docs.github.com/rest"
-}


### PR DESCRIPTION
https://silentus-au.atlassian.net/jira/software/projects/SIL/boards/1?selectedIssue=SIL-82

Changes: 
- wrapped getting access token from composable in LaunchedEffect
- removing code used for getting token from the intent

https://developer.android.com/jetpack/compose/side-effects - info about side effects. 

Source of the bug: 
- We shouldn't run such actions from composable without Launched effects. `Code` for getting access token is only for single use. In the previous version composable could run `getAccessToken` multiple times and then we were getting null from the network because stored `code` was used already. 

Note:
- I wasn't concerned about what should be shown on that screen cause it will be changed anyway. 