### PR TITLE
[SIL-62] Add loudius loading indicator to Pull Requests Screen

### DIFF
--- a/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
@@ -5,7 +5,6 @@ package com.appunite.loudius.ui.pullrequests
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -22,7 +20,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
@@ -33,6 +33,7 @@ import com.appunite.loudius.R
 import com.appunite.loudius.common.Constants
 import com.appunite.loudius.network.model.PullRequest
 import com.appunite.loudius.ui.components.LoudiusErrorScreen
+import com.appunite.loudius.ui.components.LoudiusLoadingIndicator
 import com.appunite.loudius.ui.components.LoudiusTopAppBar
 import com.appunite.loudius.ui.theme.LoudiusTheme
 import java.time.LocalDateTime
@@ -75,7 +76,7 @@ private fun PullRequestsScreenStateless(
                 buttonText = stringResource(R.string.try_again),
                 onButtonClick = { onAction(PulLRequestsAction.RetryClick) },
             )
-            isLoading -> LoadingIndicator(modifier = Modifier.padding(padding))
+            isLoading -> LoudiusLoadingIndicator()
             else -> PullRequestsList(
                 pullRequests = pullRequests,
                 modifier = Modifier.padding(padding),
@@ -83,13 +84,6 @@ private fun PullRequestsScreenStateless(
             )
         }
     })
-}
-
-@Composable
-private fun LoadingIndicator(modifier: Modifier) {
-    Box(contentAlignment = Alignment.Center, modifier = modifier.fillMaxSize()) {
-        CircularProgressIndicator()
-    }
 }
 
 @Composable


### PR DESCRIPTION
### Description
Add loading indicator to Pull Requests screen.

### Why?
We want to use our own component

### Problems
There's a visible transition between Loading Screen and PRs Screen :( It's not bad, but it's not perfect either.

### Screenshot
![Screenshot_1679299400](https://user-images.githubusercontent.com/18102775/226280570-483c4798-b73a-4719-a8a5-204e5de19039.png)
