### PR TITLE
[LD-39] Add log in error screen

### DIFF
--- a/app/src/main/java/com/appunite/loudius/MainActivity.kt
+++ b/app/src/main/java/com/appunite/loudius/MainActivity.kt
@@ -47,9 +47,15 @@ class MainActivity : ComponentActivity() {
                                 },
                             ),
                         ) {
-                            LoadingScreen(intent = intent) {
-                                navController.navigate(Screen.PullRequests.route)
-                            }
+                            LoadingScreen(
+                                intent = intent,
+                                onNavigateToPullRequest = {
+                                    navController.navigate(Screen.PullRequests.route)
+                                },
+                                onNavigateToLogin = {
+                                    navController.navigate(Screen.Login.route)
+                                },
+                            )
                         }
                         composable(route = Screen.PullRequests.route) {
                             PullRequestsScreen { owner, repo, pullRequestNumber, submissionTime ->

--- a/app/src/main/java/com/appunite/loudius/domain/AuthRepository.kt
+++ b/app/src/main/java/com/appunite/loudius/domain/AuthRepository.kt
@@ -1,6 +1,6 @@
 package com.appunite.loudius.domain
 
-import com.appunite.loudius.network.model.AccessTokenResponse
+import com.appunite.loudius.network.model.AccessToken
 
 interface AuthRepository {
 
@@ -8,7 +8,7 @@ interface AuthRepository {
         clientId: String,
         clientSecret: String,
         code: String,
-    ): Result<AccessTokenResponse>
+    ): Result<AccessToken>
 
-    fun getAccessToken(): String
+    fun getAccessToken(): AccessToken
 }

--- a/app/src/main/java/com/appunite/loudius/domain/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/appunite/loudius/domain/AuthRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.appunite.loudius.domain
 
 import com.appunite.loudius.network.datasource.AuthDataSource
+import com.appunite.loudius.network.model.AccessToken
 import com.appunite.loudius.network.model.AccessTokenResponse
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,15 +16,13 @@ class AuthRepositoryImpl @Inject constructor(
         clientId: String,
         clientSecret: String,
         code: String,
-    ): Result<AccessTokenResponse> {
+    ): Result<AccessToken> {
         val result = authDataSource.getAccessToken(clientId, clientSecret, code)
-        result.onSuccess { response ->
-            response.accessToken?.let {
-                userLocalDataSource.saveAccessToken(it)
-            }
+        result.onSuccess {
+            userLocalDataSource.saveAccessToken(it)
         }
         return result
     }
 
-    override fun getAccessToken(): String = userLocalDataSource.getAccessToken()
+    override fun getAccessToken(): AccessToken = userLocalDataSource.getAccessToken()
 }

--- a/app/src/main/java/com/appunite/loudius/domain/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/appunite/loudius/domain/AuthRepositoryImpl.kt
@@ -2,7 +2,6 @@ package com.appunite.loudius.domain
 
 import com.appunite.loudius.network.datasource.AuthDataSource
 import com.appunite.loudius.network.model.AccessToken
-import com.appunite.loudius.network.model.AccessTokenResponse
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/main/java/com/appunite/loudius/domain/UserLocalDataSource.kt
+++ b/app/src/main/java/com/appunite/loudius/domain/UserLocalDataSource.kt
@@ -2,6 +2,7 @@ package com.appunite.loudius.domain
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.appunite.loudius.network.model.AccessToken
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,9 +18,9 @@ class UserLocalDataSource @Inject constructor(@ApplicationContext context: Conte
     private val sharedPreferences: SharedPreferences =
         context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
 
-    fun saveAccessToken(accessToken: String) {
+    fun saveAccessToken(accessToken: AccessToken) {
         sharedPreferences.edit().putString(KEY_ACCESS_TOKEN, accessToken).apply()
     }
 
-    fun getAccessToken(): String = sharedPreferences.getString(KEY_ACCESS_TOKEN, null) ?: ""
+    fun getAccessToken(): AccessToken = sharedPreferences.getString(KEY_ACCESS_TOKEN, null) ?: ""
 }

--- a/app/src/main/java/com/appunite/loudius/network/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/appunite/loudius/network/datasource/AuthDataSource.kt
@@ -29,8 +29,11 @@ class AuthNetworkDataSource @Inject constructor(
     ): Result<AccessToken> =
         safeApiCall { authService.getAccessToken(clientId, clientSecret, code) }
             .flatMap { response ->
-                response.accessToken?.let { token -> Result.success(token) }
-                    ?: Result.failure(response.mapErrorToException())
+                if (response.accessToken != null) {
+                    Result.success(response.accessToken)
+                } else {
+                    Result.failure(response.mapErrorToException())
+                }
             }
 
     private fun AccessTokenResponse.mapErrorToException(): java.lang.Exception {

--- a/app/src/main/java/com/appunite/loudius/network/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/appunite/loudius/network/datasource/AuthDataSource.kt
@@ -4,6 +4,7 @@ import com.appunite.loudius.common.flatMap
 import com.appunite.loudius.network.model.AccessToken
 import com.appunite.loudius.network.model.AccessTokenResponse
 import com.appunite.loudius.network.services.AuthService
+import com.appunite.loudius.network.utils.WebException
 import com.appunite.loudius.network.utils.safeApiCall
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,10 +37,10 @@ class AuthNetworkDataSource @Inject constructor(
                 }
             }
 
-    private fun AccessTokenResponse.mapErrorToException(): java.lang.Exception {
+    private fun AccessTokenResponse.mapErrorToException(): Exception {
         return when (error) {
             BAD_VERIFICATION_CODE_ERROR -> BadVerificationCodeException
-            else -> UnknownGithubException
+            else -> WebException.UnknownError(null, error)
         }
     }
 
@@ -49,4 +50,3 @@ class AuthNetworkDataSource @Inject constructor(
 }
 
 object BadVerificationCodeException : Exception()
-object UnknownGithubException : Exception()

--- a/app/src/main/java/com/appunite/loudius/network/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/appunite/loudius/network/datasource/AuthDataSource.kt
@@ -33,9 +33,15 @@ class AuthNetworkDataSource @Inject constructor(
                     ?: Result.failure(response.mapErrorToException())
             }
 
-    private fun AccessTokenResponse.mapErrorToException() = when (error) {
-        "bad_verification_code" -> BadVerificationCodeException
-        else -> UnknownGithubException
+    private fun AccessTokenResponse.mapErrorToException(): java.lang.Exception {
+        return when (error) {
+            BAD_VERIFICATION_CODE_ERROR -> BadVerificationCodeException
+            else -> UnknownGithubException
+        }
+    }
+
+    companion object {
+        private const val BAD_VERIFICATION_CODE_ERROR = "bad_verification_code"
     }
 }
 

--- a/app/src/main/java/com/appunite/loudius/network/model/AccessTokenResponse.kt
+++ b/app/src/main/java/com/appunite/loudius/network/model/AccessTokenResponse.kt
@@ -1,6 +1,8 @@
 package com.appunite.loudius.network.model
 
+typealias AccessToken = String
+
 data class AccessTokenResponse(
-    val accessToken: String?,
+    val accessToken: AccessToken?,
     val error: String? = null,
 )

--- a/app/src/main/java/com/appunite/loudius/network/utils/WebException.kt
+++ b/app/src/main/java/com/appunite/loudius/network/utils/WebException.kt
@@ -7,7 +7,7 @@ sealed class WebException : Exception() {
     /**
      * Represents exception which comes from backend.
      */
-    data class UnknownError(val code: Int, override val message: String?) : WebException()
+    data class UnknownError(val code: Int?, override val message: String?) : WebException()
 
     /**
      * Represents web exception which can be thrown during network communication.

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorScreen.kt
@@ -55,7 +55,7 @@ private fun ErrorText(text: String) {
         color = MaterialTheme.colorScheme.error,
         style = MaterialTheme.typography.titleLarge,
         textAlign = TextAlign.Center,
-        modifier = Modifier.padding(horizontal = 16.dp)
+        modifier = Modifier.padding(horizontal = 16.dp),
     )
 }
 

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.appunite.loudius.R
@@ -53,6 +54,8 @@ private fun ErrorText(text: String) {
         text = text,
         color = MaterialTheme.colorScheme.error,
         style = MaterialTheme.typography.titleLarge,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = 16.dp)
     )
 }
 

--- a/app/src/main/java/com/appunite/loudius/ui/loading/LoadingScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/loading/LoadingScreen.kt
@@ -51,7 +51,7 @@ fun LoadingScreenStateless(
     onTryAgainClick: () -> Unit,
 ) {
     when (errorScreenType) {
-        LoadingErrorType.GENERIC_ERROR -> ShowLoudiusErrorScreen(onTryAgainClick)
+        LoadingErrorType.GENERIC_ERROR -> ShowLoudiusGenericErrorScreen(onTryAgainClick)
         LoadingErrorType.LOGIN_ERROR -> ShowLoudiusLoginErrorScreen(onTryAgainClick)
         else -> LoudiusLoadingIndicator()
     }
@@ -64,18 +64,15 @@ private fun ShowLoudiusLoginErrorScreen(
     LoudiusErrorScreen(
         errorText = stringResource(id = R.string.error_login_text),
         buttonText = stringResource(id = R.string.go_to_login),
-    ) {
-        onTryAgainClick()
-    }
+        onButtonClick = onTryAgainClick,
+    )
 }
 
 @Composable
-private fun ShowLoudiusErrorScreen(
+private fun ShowLoudiusGenericErrorScreen(
     onTryAgainClick: () -> Unit,
 ) {
-    LoudiusErrorScreen(
-        onButtonClick = { onTryAgainClick() },
-    )
+    LoudiusErrorScreen(onButtonClick = onTryAgainClick)
 }
 
 @Preview(showSystemUi = true)

--- a/app/src/main/java/com/appunite/loudius/ui/loading/LoadingScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/loading/LoadingScreen.kt
@@ -4,8 +4,10 @@ import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.appunite.loudius.R
 import com.appunite.loudius.ui.components.LoudiusErrorScreen
 import com.appunite.loudius.ui.components.LoudiusLoadingIndicator
 import com.appunite.loudius.ui.theme.LoudiusTheme
@@ -15,6 +17,7 @@ fun LoadingScreen(
     intent: Intent,
     viewModel: LoadingViewModel = hiltViewModel(),
     onNavigateToPullRequest: () -> Unit,
+    onNavigateToLogin: () -> Unit,
 ) {
     val state = viewModel.state
     val code = intent.data?.getQueryParameter("code")
@@ -24,28 +27,45 @@ fun LoadingScreen(
             viewModel.setCodeAndGetAccessToken(it)
         }
     }
-    LaunchedEffect(key1 = state.navigateToPullRequests) {
-        state.navigateToPullRequests?.let {
-            onNavigateToPullRequest()
-            viewModel.onAction(LoadingAction.OnNavigateToPullRequests)
+    LaunchedEffect(key1 = state.navigateTo) {
+        when (state.navigateTo) {
+            LoadingScreenNavigation.NavigateToLogin -> {
+                onNavigateToLogin()
+                viewModel.onAction(LoadingAction.OnNavigate)
+            }
+            LoadingScreenNavigation.NavigateToPullRequests -> {
+                onNavigateToPullRequest()
+                viewModel.onAction(LoadingAction.OnNavigate)
+            }
+            null -> {}
         }
     }
-    LoadingScreenStateless(showErrorScreen = state.showErrorScreen) {
+    LoadingScreenStateless(errorScreenType = state.errorScreenType) {
         viewModel.onAction(LoadingAction.OnTryAgainClick)
     }
 }
 
 @Composable
 fun LoadingScreenStateless(
-    showErrorScreen: Boolean,
+    errorScreenType: LoadingErrorType?,
     onTryAgainClick: () -> Unit,
 ) {
-    if (showErrorScreen) {
-        ShowLoudiusErrorScreen {
-            onTryAgainClick()
-        }
-    } else {
-        LoudiusLoadingIndicator()
+    when (errorScreenType) {
+        LoadingErrorType.GENERIC_ERROR -> ShowLoudiusErrorScreen(onTryAgainClick)
+        LoadingErrorType.LOGIN_ERROR -> ShowLoudiusLoginErrorScreen(onTryAgainClick)
+        else -> LoudiusLoadingIndicator()
+    }
+}
+
+@Composable
+private fun ShowLoudiusLoginErrorScreen(
+    onTryAgainClick: () -> Unit,
+) {
+    LoudiusErrorScreen(
+        errorText = stringResource(id = R.string.error_login_text),
+        buttonText = stringResource(id = R.string.go_to_login),
+    ) {
+        onTryAgainClick()
     }
 }
 
@@ -60,9 +80,17 @@ private fun ShowLoudiusErrorScreen(
 
 @Preview(showSystemUi = true)
 @Composable
-fun ShowLoudiusErrorScreenPreview() {
+fun ShowLoudiusGenericErrorScreenPreview() {
     LoudiusTheme {
-        LoadingScreenStateless(showErrorScreen = true) {}
+        LoadingScreenStateless(errorScreenType = LoadingErrorType.GENERIC_ERROR) {}
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun ShowLoudiusLoginErrorScreenPreview() {
+    LoudiusTheme {
+        LoadingScreenStateless(errorScreenType = LoadingErrorType.LOGIN_ERROR) {}
     }
 }
 
@@ -70,6 +98,6 @@ fun ShowLoudiusErrorScreenPreview() {
 @Composable
 fun ShowLoadingIndicatorScreenPreview() {
     LoudiusTheme {
-        LoadingScreenStateless(showErrorScreen = false) {}
+        LoadingScreenStateless(errorScreenType = null) {}
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
@@ -52,7 +52,7 @@ class LoadingViewModel @Inject constructor(
 
     fun onAction(action: LoadingAction) = when (action) {
         is LoadingAction.OnTryAgainClick -> onTryAgain()
-        is LoadingAction.OnNavigate -> onNavigateToPullRequests()
+        is LoadingAction.OnNavigate -> onNavigate()
     }
 
     private fun onTryAgain() {
@@ -66,7 +66,7 @@ class LoadingViewModel @Inject constructor(
         }
     }
 
-    private fun onNavigateToPullRequests() {
+    private fun onNavigate() {
         state = state.copy(navigateTo = null)
     }
 

--- a/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
@@ -10,8 +10,8 @@ import com.appunite.loudius.common.Constants.CLIENT_ID
 import com.appunite.loudius.domain.AuthRepository
 import com.appunite.loudius.network.datasource.BadVerificationCodeException
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 sealed class LoadingAction {
 

--- a/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
@@ -8,26 +8,34 @@ import androidx.lifecycle.viewModelScope
 import com.appunite.loudius.BuildConfig
 import com.appunite.loudius.common.Constants.CLIENT_ID
 import com.appunite.loudius.domain.AuthRepository
-import com.appunite.loudius.network.model.AccessTokenResponse
+import com.appunite.loudius.network.datasource.BadVerificationCodeException
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 sealed class LoadingAction {
 
-    object OnNavigateToPullRequests : LoadingAction()
+    object OnNavigate : LoadingAction()
 
     object OnTryAgainClick : LoadingAction()
+}
+
+enum class LoadingErrorType {
+    LOGIN_ERROR,
+    GENERIC_ERROR,
 }
 
 data class LoadingState(
     val accessToken: String? = null,
     val code: String? = null,
-    val navigateToPullRequests: NavigateToPullRequests? = null,
-    val showErrorScreen: Boolean = false,
+    val navigateTo: LoadingScreenNavigation? = null,
+    val errorScreenType: LoadingErrorType? = null,
 )
 
-object NavigateToPullRequests
+sealed class LoadingScreenNavigation {
+    object NavigateToPullRequests : LoadingScreenNavigation()
+    object NavigateToLogin : LoadingScreenNavigation()
+}
 
 @HiltViewModel
 class LoadingViewModel @Inject constructor(
@@ -44,18 +52,22 @@ class LoadingViewModel @Inject constructor(
 
     fun onAction(action: LoadingAction) = when (action) {
         is LoadingAction.OnTryAgainClick -> onTryAgain()
-        is LoadingAction.OnNavigateToPullRequests -> onNavigateToPullRequests()
+        is LoadingAction.OnNavigate -> onNavigateToPullRequests()
     }
 
     private fun onTryAgain() {
-        state = state.copy(showErrorScreen = false)
-        state.code?.let {
-            getAccessToken(it)
+        if (state.errorScreenType == LoadingErrorType.LOGIN_ERROR) {
+            state = state.copy(navigateTo = LoadingScreenNavigation.NavigateToLogin)
+        } else {
+            state = state.copy(errorScreenType = null)
+            state.code?.let {
+                getAccessToken(it)
+            }
         }
     }
 
     private fun onNavigateToPullRequests() {
-        state = state.copy(navigateToPullRequests = null)
+        state = state.copy(navigateTo = null)
     }
 
     private fun getAccessToken(code: String) {
@@ -65,20 +77,18 @@ class LoadingViewModel @Inject constructor(
                 clientSecret = BuildConfig.CLIENT_SECRET,
                 code = code,
             ).onSuccess { token ->
-                state = handleGetAccessTokenSuccess(token)
+                state = state.copy(
+                    accessToken = token,
+                    navigateTo = LoadingScreenNavigation.NavigateToPullRequests
+                )
             }.onFailure {
-                state = state.copy(showErrorScreen = true)
+                state = state.copy(
+                    errorScreenType = when (it) {
+                        is BadVerificationCodeException -> LoadingErrorType.LOGIN_ERROR
+                        else -> LoadingErrorType.GENERIC_ERROR
+                    }
+                )
             }
         }
     }
-
-    private fun handleGetAccessTokenSuccess(token: AccessTokenResponse) =
-        if (token.accessToken != null) {
-            state.copy(
-                accessToken = token.accessToken,
-                navigateToPullRequests = NavigateToPullRequests,
-            )
-        } else {
-            state.copy(showErrorScreen = true)
-        }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
@@ -10,8 +10,8 @@ import com.appunite.loudius.common.Constants.CLIENT_ID
 import com.appunite.loudius.domain.AuthRepository
 import com.appunite.loudius.network.datasource.BadVerificationCodeException
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 sealed class LoadingAction {
 
@@ -79,14 +79,14 @@ class LoadingViewModel @Inject constructor(
             ).onSuccess { token ->
                 state = state.copy(
                     accessToken = token,
-                    navigateTo = LoadingScreenNavigation.NavigateToPullRequests
+                    navigateTo = LoadingScreenNavigation.NavigateToPullRequests,
                 )
             }.onFailure {
                 state = state.copy(
                     errorScreenType = when (it) {
                         is BadVerificationCodeException -> LoadingErrorType.LOGIN_ERROR
                         else -> LoadingErrorType.GENERIC_ERROR
-                    }
+                    },
                 )
             }
         }

--- a/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/loading/LoadingViewModel.kt
@@ -10,8 +10,8 @@ import com.appunite.loudius.common.Constants.CLIENT_ID
 import com.appunite.loudius.domain.AuthRepository
 import com.appunite.loudius.network.datasource.BadVerificationCodeException
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 sealed class LoadingAction {
 
@@ -82,13 +82,13 @@ class LoadingViewModel @Inject constructor(
                     navigateTo = LoadingScreenNavigation.NavigateToPullRequests,
                 )
             }.onFailure {
-                state = state.copy(
-                    errorScreenType = when (it) {
-                        is BadVerificationCodeException -> LoadingErrorType.LOGIN_ERROR
-                        else -> LoadingErrorType.GENERIC_ERROR
-                    },
-                )
+                state = state.copy(errorScreenType = resolveErrorType(it))
             }
         }
+    }
+
+    private fun resolveErrorType(it: Throwable) = when (it) {
+        is BadVerificationCodeException -> LoadingErrorType.LOGIN_ERROR
+        else -> LoadingErrorType.GENERIC_ERROR
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,5 +14,7 @@
     <string name="ok">OK</string>
     <string name="error_image_desc">error image</string>
     <string name="try_again">Try again</string>
+    <string name="error_login_text">Something went wrong…\nYou need to log in again.</string>
+    <string name="go_to_login">Take me to login</string>
     <string name="reviewers_snackbar_message">Awesome! Your collaborator have been pinged for some serious code review action! 🎉</string>
 </resources>

--- a/app/src/test/java/com/appunite/loudius/domain/AuthRepositoryImplTest.kt
+++ b/app/src/test/java/com/appunite/loudius/domain/AuthRepositoryImplTest.kt
@@ -1,7 +1,6 @@
 package com.appunite.loudius.domain
 
 import com.appunite.loudius.network.datasource.AuthDataSource
-import com.appunite.loudius.network.model.AccessTokenResponse
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every

--- a/app/src/test/java/com/appunite/loudius/domain/AuthRepositoryImplTest.kt
+++ b/app/src/test/java/com/appunite/loudius/domain/AuthRepositoryImplTest.kt
@@ -16,7 +16,7 @@ class AuthRepositoryImplTest {
     private val networkDataSource: AuthDataSource = mockk {
         coEvery {
             getAccessToken(any(), any(), any())
-        } returns Result.success(AccessTokenResponse("validAccessToken"))
+        } returns Result.success("validAccessToken")
     }
     private val localDataSource: UserLocalDataSource = mockk {
         every { getAccessToken() } returns "validAccessToken"
@@ -27,11 +27,11 @@ class AuthRepositoryImplTest {
     @Test
     fun `GIVEN fetch access token function WHEN processing THEN return success with new valid token`() =
         runTest {
-            val result = repository.fetchAccessToken("clientId", "clientSecret", "code")
+            val result = repository.fetchAccessToken("clientId", "clientSecret", "validCode")
 
             coVerify(exactly = 1) { networkDataSource.getAccessToken(any(), any(), any()) }
             assertEquals(
-                Result.success(AccessTokenResponse("validAccessToken")),
+                Result.success("validAccessToken"),
                 result,
             ) { "Expected success result with valid access token" }
         }
@@ -39,7 +39,7 @@ class AuthRepositoryImplTest {
     @Test
     fun `GIVEN fetch access token WHEN processing THEN new token should be saved`() =
         runTest {
-            repository.fetchAccessToken("clientId", "clientSecret", "code")
+            repository.fetchAccessToken("clientId", "clientSecret", "validCode")
 
             coVerify(exactly = 1) { localDataSource.saveAccessToken("validAccessToken") }
         }

--- a/app/src/test/java/com/appunite/loudius/fakes/FakeAuthRepository.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakeAuthRepository.kt
@@ -1,16 +1,21 @@
 package com.appunite.loudius.fakes
 
 import com.appunite.loudius.domain.AuthRepository
-import com.appunite.loudius.network.model.AccessTokenResponse
+import com.appunite.loudius.network.datasource.BadVerificationCodeException
+import com.appunite.loudius.network.datasource.UnknownGithubException
+import com.appunite.loudius.network.model.AccessToken
 
 class FakeAuthRepository : AuthRepository {
     override suspend fun fetchAccessToken(
         clientId: String,
         clientSecret: String,
         code: String,
-    ): Result<AccessTokenResponse> {
-        return Result.success(AccessTokenResponse("validToken"))
+    ): Result<AccessToken> = when (code) {
+        "validCode" -> Result.success("validToken")
+        "invalidCode" -> Result.failure(BadVerificationCodeException)
+        else -> Result.failure(UnknownGithubException)
     }
+
 
     override fun getAccessToken(): String {
         return "validToken"

--- a/app/src/test/java/com/appunite/loudius/fakes/FakeAuthRepository.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakeAuthRepository.kt
@@ -16,7 +16,6 @@ class FakeAuthRepository : AuthRepository {
         else -> Result.failure(UnknownGithubException)
     }
 
-
     override fun getAccessToken(): String {
         return "validToken"
     }

--- a/app/src/test/java/com/appunite/loudius/fakes/FakeAuthRepository.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakeAuthRepository.kt
@@ -2,8 +2,8 @@ package com.appunite.loudius.fakes
 
 import com.appunite.loudius.domain.AuthRepository
 import com.appunite.loudius.network.datasource.BadVerificationCodeException
-import com.appunite.loudius.network.datasource.UnknownGithubException
 import com.appunite.loudius.network.model.AccessToken
+import com.appunite.loudius.network.utils.WebException
 
 class FakeAuthRepository : AuthRepository {
     override suspend fun fetchAccessToken(
@@ -13,7 +13,7 @@ class FakeAuthRepository : AuthRepository {
     ): Result<AccessToken> = when (code) {
         "validCode" -> Result.success("validToken")
         "invalidCode" -> Result.failure(BadVerificationCodeException)
-        else -> Result.failure(UnknownGithubException)
+        else -> Result.failure(WebException.UnknownError(null, null))
     }
 
     override fun getAccessToken(): String {

--- a/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
@@ -2,23 +2,50 @@
 
 package com.appunite.loudius.network.datasource
 
+import com.appunite.loudius.fakes.FakeAuthRepository
 import com.appunite.loudius.network.model.AccessToken
-import com.appunite.loudius.network.model.AccessTokenResponse
+import com.appunite.loudius.network.retrofitTestDouble
 import com.appunite.loudius.network.services.AuthService
+import com.appunite.loudius.network.testOkHttpClient
 import com.appunite.loudius.network.utils.WebException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class AuthNetworkDataSourceTest {
-    private val authService = FakeAuthService()
+    private val fakeUserRepository = FakeAuthRepository()
+    private val testOkHttpClient = testOkHttpClient(fakeUserRepository)
+    private val mockWebServer: MockWebServer = MockWebServer()
+    private val authService = retrofitTestDouble(
+        mockWebServer = mockWebServer,
+        client = testOkHttpClient,
+    ).create(AuthService::class.java)
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
     private val authNetworkDataSource = AuthNetworkDataSource(authService)
 
     @Test
-    fun `GIVEN correct data WHEN processing THEN return success with new valid token`() =
+    fun `GIVEN correct data WHEN accessing token THEN return success with new valid token`() =
         runTest {
-            val result = authNetworkDataSource.getAccessToken("clientId", "clientSecret", "correctCode")
+            //language=JSON
+            val jsonResponse = """
+            { "access_token": "validAccessToken" }
+        """.trimIndent()
+
+            mockWebServer.enqueue(
+                MockResponse().setResponseCode(200).setBody(jsonResponse),
+            )
+
+            val result =
+                authNetworkDataSource.getAccessToken("clientId", "clientSecret", "correctCode")
 
             Assertions.assertEquals(
                 Result.success("validAccessToken"),
@@ -29,6 +56,15 @@ class AuthNetworkDataSourceTest {
     @Test
     fun `GIVEN incorrect access code WHEN accessing token THEN return failure with BadVerificationCodeException`() =
         runTest {
+            //language=JSON
+            val jsonResponse = """
+            { "error": "bad_verification_code" }
+        """.trimIndent()
+
+            mockWebServer.enqueue(
+                MockResponse().setResponseCode(200).setBody(jsonResponse),
+            )
+
             val result = authNetworkDataSource.getAccessToken("clientId", "clientSecret", "incorrectCode")
 
             Assertions.assertEquals(
@@ -38,8 +74,17 @@ class AuthNetworkDataSourceTest {
         }
 
     @Test
-    fun `GIVEN incorrect data WHEN processing THEN return failure with UnknownError`() =
+    fun `GIVEN incorrect data WHEN accessing token THEN return failure with UnknownError`() =
         runTest {
+            //language=JSON
+            val jsonResponse = """
+            { "error": "error" }
+        """.trimIndent()
+
+            mockWebServer.enqueue(
+                MockResponse().setResponseCode(200).setBody(jsonResponse),
+            )
+
             val result = authNetworkDataSource.getAccessToken("", "", "")
 
             Assertions.assertEquals(
@@ -47,16 +92,4 @@ class AuthNetworkDataSourceTest {
                 result,
             )
         }
-}
-
-class FakeAuthService : AuthService {
-    override suspend fun getAccessToken(
-        clientId: String,
-        clientSecret: String,
-        code: String,
-    ): AccessTokenResponse = when (code) {
-        "correctCode" -> AccessTokenResponse("validAccessToken")
-        "incorrectCode" -> AccessTokenResponse(null, "bad_verification_code")
-        else -> AccessTokenResponse(null, "error")
-    }
 }

--- a/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
@@ -52,7 +52,7 @@ class FakeAuthService : AuthService {
     override suspend fun getAccessToken(
         clientId: String,
         clientSecret: String,
-        code: String
+        code: String,
     ): AccessTokenResponse = when (code) {
         "correct_code" -> AccessTokenResponse("validAccessToken")
         "incorrect_code" -> AccessTokenResponse(null, "bad_verification_code")

--- a/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
@@ -38,7 +38,7 @@ class AuthNetworkDataSourceTest {
             //language=JSON
             val jsonResponse = """
             { "access_token": "validAccessToken" }
-        """.trimIndent()
+            """.trimIndent()
 
             mockWebServer.enqueue(
                 MockResponse().setResponseCode(200).setBody(jsonResponse),
@@ -59,7 +59,7 @@ class AuthNetworkDataSourceTest {
             //language=JSON
             val jsonResponse = """
             { "error": "bad_verification_code" }
-        """.trimIndent()
+            """.trimIndent()
 
             mockWebServer.enqueue(
                 MockResponse().setResponseCode(200).setBody(jsonResponse),
@@ -79,7 +79,7 @@ class AuthNetworkDataSourceTest {
             //language=JSON
             val jsonResponse = """
             { "error": "error" }
-        """.trimIndent()
+            """.trimIndent()
 
             mockWebServer.enqueue(
                 MockResponse().setResponseCode(200).setBody(jsonResponse),

--- a/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
@@ -5,6 +5,7 @@ package com.appunite.loudius.network.datasource
 import com.appunite.loudius.network.model.AccessToken
 import com.appunite.loudius.network.model.AccessTokenResponse
 import com.appunite.loudius.network.services.AuthService
+import com.appunite.loudius.network.utils.WebException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
@@ -37,12 +38,12 @@ class AuthNetworkDataSourceTest {
         }
 
     @Test
-    fun `GIVEN incorrect data WHEN processing THEN return failure with UnknownGithubException`() =
+    fun `GIVEN incorrect data WHEN processing THEN return failure with UnknownError`() =
         runTest {
             val result = authNetworkDataSource.getAccessToken("", "", "")
 
             Assertions.assertEquals(
-                Result.failure<AccessToken>(UnknownGithubException),
+                Result.failure<AccessToken>(WebException.UnknownError(null, "error")),
                 result,
             )
         }

--- a/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
@@ -17,7 +17,7 @@ class AuthNetworkDataSourceTest {
     @Test
     fun `GIVEN correct data WHEN processing THEN return success with new valid token`() =
         runTest {
-            val result = authNetworkDataSource.getAccessToken("clientId", "clientSecret", "correct_code")
+            val result = authNetworkDataSource.getAccessToken("clientId", "clientSecret", "correctCode")
 
             Assertions.assertEquals(
                 Result.success("validAccessToken"),
@@ -28,7 +28,7 @@ class AuthNetworkDataSourceTest {
     @Test
     fun `GIVEN incorrect access code WHEN accessing token THEN return failure with BadVerificationCodeException`() =
         runTest {
-            val result = authNetworkDataSource.getAccessToken("clientId", "clientSecret", "incorrect_code")
+            val result = authNetworkDataSource.getAccessToken("clientId", "clientSecret", "incorrectCode")
 
             Assertions.assertEquals(
                 Result.failure<AccessToken>(BadVerificationCodeException),
@@ -54,8 +54,8 @@ class FakeAuthService : AuthService {
         clientSecret: String,
         code: String,
     ): AccessTokenResponse = when (code) {
-        "correct_code" -> AccessTokenResponse("validAccessToken")
-        "incorrect_code" -> AccessTokenResponse(null, "bad_verification_code")
+        "correctCode" -> AccessTokenResponse("validAccessToken")
+        "incorrectCode" -> AccessTokenResponse(null, "bad_verification_code")
         else -> AccessTokenResponse(null, "error")
     }
 }

--- a/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/appunite/loudius/network/datasource/AuthNetworkDataSourceTest.kt
@@ -1,0 +1,61 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.appunite.loudius.network.datasource
+
+import com.appunite.loudius.network.model.AccessToken
+import com.appunite.loudius.network.model.AccessTokenResponse
+import com.appunite.loudius.network.services.AuthService
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AuthNetworkDataSourceTest {
+    private val authService = FakeAuthService()
+    private val authNetworkDataSource = AuthNetworkDataSource(authService)
+
+    @Test
+    fun `GIVEN correct data WHEN processing THEN return success with new valid token`() =
+        runTest {
+            val result = authNetworkDataSource.getAccessToken("clientId", "clientSecret", "correct_code")
+
+            Assertions.assertEquals(
+                Result.success("validAccessToken"),
+                result,
+            )
+        }
+
+    @Test
+    fun `GIVEN incorrect access code WHEN accessing token THEN return failure with BadVerificationCodeException`() =
+        runTest {
+            val result = authNetworkDataSource.getAccessToken("clientId", "clientSecret", "incorrect_code")
+
+            Assertions.assertEquals(
+                Result.failure<AccessToken>(BadVerificationCodeException),
+                result,
+            )
+        }
+
+    @Test
+    fun `GIVEN incorrect data WHEN processing THEN return failure with UnknownGithubException`() =
+        runTest {
+            val result = authNetworkDataSource.getAccessToken("", "", "")
+
+            Assertions.assertEquals(
+                Result.failure<AccessToken>(UnknownGithubException),
+                result,
+            )
+        }
+}
+
+class FakeAuthService : AuthService {
+    override suspend fun getAccessToken(
+        clientId: String,
+        clientSecret: String,
+        code: String
+    ): AccessTokenResponse = when (code) {
+        "correct_code" -> AccessTokenResponse("validAccessToken")
+        "incorrect_code" -> AccessTokenResponse(null, "bad_verification_code")
+        else -> AccessTokenResponse(null, "error")
+    }
+}

--- a/app/src/test/java/com/appunite/loudius/ui/loading/LoadingViewModelTest.kt
+++ b/app/src/test/java/com/appunite/loudius/ui/loading/LoadingViewModelTest.kt
@@ -3,7 +3,7 @@ package com.appunite.loudius.ui.loading
 import com.appunite.loudius.fakes.FakeAuthRepository
 import com.appunite.loudius.util.MainDispatcherExtension
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -11,25 +11,21 @@ import org.junit.jupiter.api.extension.ExtendWith
 class LoadingViewModelTest {
 
     companion object {
-        private const val EXAMPLE_CODE = "code"
+        private const val EXAMPLE_CODE = "validCode"
+        private const val EXAMPLE_INVALID_CODE = "invalidCode"
         private const val EXAMPLE_ACCESS_TOKEN = "validToken"
     }
 
     private val repository: FakeAuthRepository = FakeAuthRepository()
-    private lateinit var viewModel: LoadingViewModel
-
-    @BeforeEach
-    fun setup() {
-        viewModel = LoadingViewModel(repository)
-    }
+    private val viewModel = LoadingViewModel(repository)
 
     @Test
-    fun `GIVEN valid code WHEN setCodeAndGetAccessToken THEN set code, access token and navigateToPullRequests`() {
+    fun `GIVEN valid code WHEN setCodeAndGetAccessToken THEN set code, access token and navigate to pull requests`() {
         viewModel.setCodeAndGetAccessToken(EXAMPLE_CODE)
 
-        assertEquals(viewModel.state.code, EXAMPLE_CODE)
-        assertEquals(viewModel.state.accessToken, EXAMPLE_ACCESS_TOKEN)
-        assertEquals(viewModel.state.navigateToPullRequests, NavigateToPullRequests)
+        assertEquals(EXAMPLE_CODE, viewModel.state.code)
+        assertEquals(EXAMPLE_ACCESS_TOKEN, viewModel.state.accessToken)
+        assertEquals(LoadingScreenNavigation.NavigateToPullRequests, viewModel.state.navigateTo)
     }
 
     @Test
@@ -39,17 +35,42 @@ class LoadingViewModelTest {
 
         viewModel.onAction(action)
 
-        assertEquals(viewModel.state.showErrorScreen, false)
-        assertEquals(viewModel.state.accessToken, EXAMPLE_ACCESS_TOKEN)
+        assertNull(viewModel.state.errorScreenType)
+        assertEquals(EXAMPLE_ACCESS_TOKEN, viewModel.state.accessToken)
     }
 
     @Test
-    fun `GIVEN OnNavigateToPullRequests action WHEN onAction THEN set navigateToPullRequests as null`() {
-        val action = LoadingAction.OnNavigateToPullRequests
+    fun `GIVEN OnNavigateToPullRequests action WHEN onAction THEN set navigateToPullRequests to null`() {
+        val action = LoadingAction.OnNavigate
         viewModel.setCodeAndGetAccessToken(EXAMPLE_CODE)
 
         viewModel.onAction(action)
 
-        assertEquals(viewModel.state.navigateToPullRequests, null)
+        assertNull(viewModel.state.navigateTo)
+    }
+
+    @Test
+    fun `GIVEN invalid code WHEN setCodeAndGetAccessToken THEN show login error screen`() {
+        viewModel.setCodeAndGetAccessToken(EXAMPLE_INVALID_CODE)
+
+        assertEquals(LoadingErrorType.LOGIN_ERROR, viewModel.state.errorScreenType)
+        assertNull(viewModel.state.navigateTo)
+    }
+
+    @Test
+    fun `GIVEN unexpected Github behavior WHEN setCodeAndGetAccessToken THEN show generic error screen`() {
+        viewModel.setCodeAndGetAccessToken("code_leading_to_unexpected_error")
+
+        assertEquals(LoadingErrorType.GENERIC_ERROR, viewModel.state.errorScreenType)
+        assertNull(viewModel.state.navigateTo)
+    }
+
+    @Test
+    fun `GIVEN retry click WHEN logging in error THEN redirect to login screen`() {
+        viewModel.setCodeAndGetAccessToken(EXAMPLE_INVALID_CODE)
+
+        viewModel.onAction(LoadingAction.OnTryAgainClick)
+
+        assertEquals(LoadingScreenNavigation.NavigateToLogin, viewModel.state.navigateTo)
     }
 }

--- a/app/src/test/java/com/appunite/loudius/ui/loading/LoadingViewModelTest.kt
+++ b/app/src/test/java/com/appunite/loudius/ui/loading/LoadingViewModelTest.kt
@@ -59,7 +59,7 @@ class LoadingViewModelTest {
 
     @Test
     fun `GIVEN unexpected Github behavior WHEN setCodeAndGetAccessToken THEN show generic error screen`() {
-        viewModel.setCodeAndGetAccessToken("code_leading_to_unexpected_error")
+        viewModel.setCodeAndGetAccessToken("codeLeadingToUnexpectedError")
 
         assertEquals(LoadingErrorType.GENERIC_ERROR, viewModel.state.errorScreenType)
         assertNull(viewModel.state.navigateTo)

--- a/app/src/test/java/com/appunite/loudius/ui/loading/LoadingViewModelTest.kt
+++ b/app/src/test/java/com/appunite/loudius/ui/loading/LoadingViewModelTest.kt
@@ -13,6 +13,7 @@ class LoadingViewModelTest {
     companion object {
         private const val EXAMPLE_CODE = "validCode"
         private const val EXAMPLE_INVALID_CODE = "invalidCode"
+        private const val EXAMPLE_CODE_LEADING_TO_UNEXPECTED_ERROR = "codeLeadingToUnexpectedError"
         private const val EXAMPLE_ACCESS_TOKEN = "validToken"
     }
 
@@ -59,7 +60,7 @@ class LoadingViewModelTest {
 
     @Test
     fun `GIVEN unexpected Github behavior WHEN setCodeAndGetAccessToken THEN show generic error screen`() {
-        viewModel.setCodeAndGetAccessToken("codeLeadingToUnexpectedError")
+        viewModel.setCodeAndGetAccessToken(EXAMPLE_CODE_LEADING_TO_UNEXPECTED_ERROR)
 
         assertEquals(LoadingErrorType.GENERIC_ERROR, viewModel.state.errorScreenType)
         assertNull(viewModel.state.navigateTo)


### PR DESCRIPTION
### Description
- Added handling incorrect code inside deeplinks. If the code is wrong, we display a different error screen, leading users to log in again.

### Screenshot
<img src="https://user-images.githubusercontent.com/18102775/226907230-8d25bcd5-f566-4bfd-8720-1a85e9eaff36.png" width="50%" height="50%">

### Testing
If you'd like to easily open the incorrect deeplink then copy the command below to your terminal.
`adb shell am start -a android.intent.action.VIEW -d "loudius://callback?code=123" com.appunite.loudius`