### PR TITLE
[LD-49] Manage navigation back stack

### DIFF
--- a/app/src/main/java/com/appunite/loudius/MainActivity.kt
+++ b/app/src/main/java/com/appunite/loudius/MainActivity.kt
@@ -50,10 +50,14 @@ class MainActivity : ComponentActivity() {
                             LoadingScreen(
                                 intent = intent,
                                 onNavigateToPullRequest = {
-                                    navController.navigate(Screen.PullRequests.route)
+                                    navController.navigate(Screen.PullRequests.route) {
+                                        popUpTo(Screen.Login.route) { inclusive = true }
+                                    }
                                 },
                                 onNavigateToLogin = {
-                                    navController.navigate(Screen.Login.route)
+                                    navController.navigate(Screen.Login.route) {
+                                        popUpTo(Screen.Login.route) { inclusive = true }
+                                    }
                                 },
                             )
                         }


### PR DESCRIPTION
### Description
Added popping up the back stack after the login screen.  It forbids entering the login screen after a successful login and prevents having the login screen twice in the back stack after deeplink error.

### Testing
- [x] Clicking back in the PRs list should close the app
- [x] 1. Open the app. 2. In the terminal type `adb shell am start -a android.intent.action.VIEW -d "loudius://callback?code=123" com.appunite.loudius`. 3. Click the button navigating to login. 4. Click the back button 5. The app should close.