### PR TITLE
[LD-59] Refactor FakePullRequestRepository to not use setters, resetters, lazy messages

### DIFF
--- a/app/src/test/java/com/appunite/loudius/fakes/FakePullRequestRepository.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakePullRequestRepository.kt
@@ -24,92 +24,36 @@ import com.appunite.loudius.network.utils.WebException
 import com.appunite.loudius.util.Defaults
 
 class FakePullRequestRepository : PullRequestRepository {
-
-    private val initialReviewsAnswer = Result.success(Defaults.reviews())
-    private val initialRequestedReviewersAnswer = Result.success(
-        RequestedReviewersResponse(Defaults.requestedReviewers()),
-    )
-    private val initialPullRequestAnswer = Result.success(
-        PullRequestsResponse(
-            incompleteResults = false,
-            totalCount = 1,
-            items = listOf(
-                Defaults.pullRequest(),
-            ),
-        ),
-    )
-
-    private val initialNotifyAnswer: suspend (pullRequestNumber: String) -> Result<Unit> =
-        { pullRequestNumber: String ->
-            when (pullRequestNumber) {
-                "correctPullRequestNumber" -> Result.success(Unit)
-                "notExistingPullRequestNumber" -> Result.failure(
-                    WebException.UnknownError(404, null),
-                )
-                else -> Result.failure(WebException.NetworkError())
-            }
-        }
-
-    private var lazyReviewsAnswer: suspend () -> Result<List<Review>> = { initialReviewsAnswer }
-    private var lazyRequestedReviewersAnswer: suspend () -> Result<RequestedReviewersResponse> =
-        { initialRequestedReviewersAnswer }
-    private var lazyCurrentUserPullRequests: suspend () -> Result<PullRequestsResponse> =
-        { initialPullRequestAnswer }
-    private var lazyNotifyAnswer: suspend (pullRequestNumber: String) -> Result<Unit> =
-        initialNotifyAnswer
-
     override suspend fun getReviews(
         owner: String,
         repo: String,
         pullRequestNumber: String,
-    ): Result<List<Review>> = lazyReviewsAnswer()
-
-    fun setReviewsAnswer(result: suspend () -> Result<List<Review>>) {
-        lazyReviewsAnswer = result
-    }
-
-    fun resetReviewsAnswer() {
-        lazyReviewsAnswer = { initialReviewsAnswer }
-    }
+    ): Result<List<Review>> = Result.success(Defaults.reviews())
 
     override suspend fun getRequestedReviewers(
         owner: String,
         repo: String,
         pullRequestNumber: String,
-    ): Result<RequestedReviewersResponse> = lazyRequestedReviewersAnswer()
+    ): Result<RequestedReviewersResponse> =
+        Result.success(RequestedReviewersResponse(Defaults.requestedReviewers()))
 
-    fun setRequestedReviewersAnswer(result: suspend () -> Result<RequestedReviewersResponse>) {
-        lazyRequestedReviewersAnswer = result
-    }
-
-    fun resetRequestedReviewersAnswer() {
-        lazyRequestedReviewersAnswer = { initialRequestedReviewersAnswer }
-    }
-
-    fun setCurrentUserPullRequests(result: suspend () -> Result<PullRequestsResponse>) {
-        lazyCurrentUserPullRequests = result
-    }
-
-    fun resetCurrentUserPullRequestAnswer() {
-        lazyCurrentUserPullRequests = { initialPullRequestAnswer }
-    }
-
-    override suspend fun getCurrentUserPullRequests(): Result<PullRequestsResponse> {
-        return lazyCurrentUserPullRequests()
-    }
-
-    fun setNotifyResponse(result: suspend (pullRequestNumber: String) -> Result<Unit>) {
-        lazyNotifyAnswer = result
-    }
-
-    fun resetNotifyResponse() {
-        lazyNotifyAnswer = initialNotifyAnswer
-    }
+    override suspend fun getCurrentUserPullRequests(): Result<PullRequestsResponse> =
+        Result.success(
+            PullRequestsResponse(
+                incompleteResults = false,
+                totalCount = 1,
+                items = listOf(Defaults.pullRequest())
+            )
+        )
 
     override suspend fun notify(
         owner: String,
         repo: String,
         pullRequestNumber: String,
         message: String,
-    ): Result<Unit> = lazyNotifyAnswer(pullRequestNumber)
+    ): Result<Unit> = when (pullRequestNumber) {
+        "correctPullRequestNumber" -> Result.success(Unit)
+        "notExistingPullRequestNumber" -> Result.failure(WebException.UnknownError(404, null))
+        else -> Result.failure(WebException.NetworkError())
+    }
 }

--- a/app/src/test/java/com/appunite/loudius/fakes/FakePullRequestRepository.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakePullRequestRepository.kt
@@ -42,8 +42,8 @@ class FakePullRequestRepository : PullRequestRepository {
             PullRequestsResponse(
                 incompleteResults = false,
                 totalCount = 1,
-                items = listOf(Defaults.pullRequest())
-            )
+                items = listOf(Defaults.pullRequest()),
+            ),
         )
 
     override suspend fun notify(

--- a/app/src/test/java/com/appunite/loudius/fakes/FakePullRequestRepository.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakePullRequestRepository.kt
@@ -53,7 +53,6 @@ class FakePullRequestRepository : PullRequestRepository {
         message: String,
     ): Result<Unit> = when (pullRequestNumber) {
         "correctPullRequestNumber" -> Result.success(Unit)
-        "notExistingPullRequestNumber" -> Result.failure(WebException.UnknownError(404, null))
-        else -> Result.failure(WebException.NetworkError())
+        else -> Result.failure(WebException.UnknownError(404, null))
     }
 }

--- a/app/src/test/java/com/appunite/loudius/ui/reviewers/ReviewersViewModelTest.kt
+++ b/app/src/test/java/com/appunite/loudius/ui/reviewers/ReviewersViewModelTest.kt
@@ -22,10 +22,17 @@ import com.appunite.loudius.network.model.RequestedReviewersResponse
 import com.appunite.loudius.network.utils.WebException
 import com.appunite.loudius.util.MainDispatcherExtension
 import com.appunite.loudius.utils.neverCompletingSuspension
+import io.mockk.clearMocks
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.spyk
 import io.mockk.verify
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -36,10 +43,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import java.time.Clock
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZoneOffset
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MainDispatcherExtension::class)
@@ -49,7 +52,7 @@ class ReviewersViewModelTest {
     private val systemClockFixed =
         Clock.fixed(systemNow.toInstant(ZoneOffset.UTC), ZoneId.of("UTC"))
 
-    private val repository = FakePullRequestRepository()
+    private val repository = spyk(FakePullRequestRepository())
     private val savedStateHandle: SavedStateHandle = mockk(relaxed = true) {
         every { get<String>(any()) } returns "example"
         every { get<String>("submission_date") } returns "2022-01-29T08:00:00"
@@ -71,9 +74,7 @@ class ReviewersViewModelTest {
         fun `GIVEN no values in saved state WHEN init THEN throw IllegalStateException`() {
             every { savedStateHandle.get<String>(any()) } returns null
 
-            assertThrows<java.lang.IllegalStateException> {
-                createViewModel()
-            }
+            assertThrows<IllegalStateException> { createViewModel() }
         }
 
         @Test
@@ -95,7 +96,7 @@ class ReviewersViewModelTest {
 
         @Test
         fun `GIVEN correct initial values WHEN init starts THEN state is loading`() = runTest {
-            repository.setReviewsAnswer { neverCompletingSuspension() }
+            coEvery { repository.getReviews(any(), any(), any()) } coAnswers { neverCompletingSuspension() }
             viewModel = createViewModel()
 
             assertEquals(true, viewModel.state.isLoading)
@@ -104,10 +105,8 @@ class ReviewersViewModelTest {
 
         @Test
         fun `GIVEN no reviewers WHEN init THEN state is correct with no reviewers`() {
-            repository.setReviewsAnswer { Result.success(emptyList()) }
-            repository.setRequestedReviewersAnswer {
-                Result.success(RequestedReviewersResponse(emptyList()))
-            }
+            coEvery { repository.getReviews(any(), any(), any()) } returns Result.success(emptyList())
+            coEvery { repository.getRequestedReviewers(any(), any(), any()) } returns Result.success(RequestedReviewersResponse(emptyList()))
 
             viewModel = createViewModel()
 
@@ -135,7 +134,7 @@ class ReviewersViewModelTest {
         @Test
         fun `GIVEN reviewers with no review done WHEN init THEN list of reviewers is fetched`() =
             runTest {
-                repository.setReviewsAnswer { Result.success(emptyList()) }
+                coEvery { repository.getReviews(any(), any(), any()) } returns Result.success(emptyList())
                 viewModel = createViewModel()
 
                 val expected = listOf(
@@ -150,9 +149,7 @@ class ReviewersViewModelTest {
         @Test
         fun `GIVEN only reviewers who done reviews WHEN init THEN list of reviewers is fetched`() =
             runTest {
-                repository.setRequestedReviewersAnswer {
-                    Result.success(RequestedReviewersResponse(emptyList()))
-                }
+                coEvery { repository.getRequestedReviewers(any(), any(), any()) } returns Result.success(RequestedReviewersResponse(emptyList()))
                 viewModel = createViewModel()
 
                 val expected = listOf(
@@ -167,8 +164,8 @@ class ReviewersViewModelTest {
         @Test
         fun `WHEN there is an error during fetching data from 2 requests on init THEN error is shown`() =
             runTest {
-                repository.setReviewsAnswer { Result.failure(WebException.NetworkError()) }
-                repository.setRequestedReviewersAnswer { Result.failure(WebException.NetworkError()) }
+                coEvery { repository.getReviews(any(), any(), any()) } returns Result.failure(WebException.NetworkError())
+                coEvery { repository.getRequestedReviewers(any(), any(), any()) } returns Result.failure(WebException.NetworkError())
                 viewModel = createViewModel()
 
                 assertEquals(true, viewModel.state.isError)
@@ -179,7 +176,7 @@ class ReviewersViewModelTest {
         @Test
         fun `WHEN there is an error during fetching data on init only from requested reviewers request THEN error is shown`() =
             runTest {
-                repository.setRequestedReviewersAnswer { Result.failure(WebException.NetworkError()) }
+                coEvery { repository.getRequestedReviewers(any(), any(), any()) } returns Result.failure(WebException.NetworkError())
                 viewModel = createViewModel()
 
                 assertEquals(true, viewModel.state.isError)
@@ -190,7 +187,7 @@ class ReviewersViewModelTest {
         @Test
         fun `WHEN there is an error during fetching data on init only from reviews request THEN error is shown`() =
             runTest {
-                repository.setReviewsAnswer { Result.failure(WebException.NetworkError()) }
+                coEvery { repository.getReviews(any(), any(), any()) } returns Result.failure(WebException.NetworkError())
                 viewModel = createViewModel()
 
                 assertEquals(true, viewModel.state.isError)
@@ -214,7 +211,7 @@ class ReviewersViewModelTest {
         @Test
         fun `WHEN successful notify action THEN show loading indicator`() = runTest {
             viewModel = createViewModel()
-            repository.setNotifyResponse { neverCompletingSuspension() }
+            coEvery { repository.notify(any(), any(), any(), any()) } coAnswers { neverCompletingSuspension() }
 
             viewModel.onAction(ReviewersAction.Notify("user1"))
 
@@ -250,12 +247,15 @@ class ReviewersViewModelTest {
         @Test
         fun `GIVEN error state WHEN on try again action with success result THEN state has reviewers`() =
             runTest {
-                repository.setReviewsAnswer { Result.failure(WebException.NetworkError()) }
-                repository.setRequestedReviewersAnswer { Result.failure(WebException.NetworkError()) }
+                coEvery {
+                    repository.getReviews(any(), any(), any())
+                } returns Result.failure(WebException.NetworkError())
+                coEvery {
+                    repository.getRequestedReviewers(any(), any(), any())
+                } returns Result.failure(WebException.NetworkError())
                 viewModel = createViewModel()
 
-                repository.resetReviewsAnswer()
-                repository.resetRequestedReviewersAnswer()
+                clearMocks(repository)
                 viewModel.onAction(ReviewersAction.OnTryAgain)
 
                 val expected = listOf(
@@ -274,8 +274,12 @@ class ReviewersViewModelTest {
         @Test
         fun `GIVEN error state WHEN on try again action with failure result THEN error is shown`() =
             runTest {
-                repository.setReviewsAnswer { Result.failure(WebException.NetworkError()) }
-                repository.setRequestedReviewersAnswer { Result.failure(WebException.NetworkError()) }
+                coEvery {
+                    repository.getReviews(any(), any(), any())
+                } returns Result.failure(WebException.NetworkError())
+                coEvery {
+                    repository.getRequestedReviewers(any(), any(), any())
+                } returns Result.failure(WebException.NetworkError())
                 viewModel = createViewModel()
 
                 viewModel.onAction(ReviewersAction.OnTryAgain)

--- a/app/src/test/java/com/appunite/loudius/ui/reviewers/ReviewersViewModelTest.kt
+++ b/app/src/test/java/com/appunite/loudius/ui/reviewers/ReviewersViewModelTest.kt
@@ -29,10 +29,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
-import java.time.Clock
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZoneOffset
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -43,6 +39,10 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MainDispatcherExtension::class)


### PR DESCRIPTION
### Description
Based on https://github.com/appunite/Loudius/pull/59 we've decided to refactor FakePullRequestRepository. Now all of the setters, resetters, and lazy messages are removed.  These led to changes in `PullRequestsViewModelTest` and `ReviewersViewModelTest`, but now everything seems much more readable
