### PR TITLE
[LD-67] Minor code improvements

### DIFF
--- a/app/src/main/java/com/appunite/loudius/common/Constants.kt
+++ b/app/src/main/java/com/appunite/loudius/common/Constants.kt
@@ -25,4 +25,6 @@ object Constants {
     const val SCOPE_PARAM = "&scope=repo"
     const val CLIENT_ID = "91131449e417c7e29912"
     const val REDIRECT_URL = "loudius://callback"
+    const val AUTHORIZATION_URL =
+        AUTH_API_URL + AUTH_PATH + NAME_PARAM_CLIENT_ID + CLIENT_ID + SCOPE_PARAM
 }

--- a/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.appunite.loudius.R
-import com.appunite.loudius.ui.components.LoudiusErrorScreen
+import com.appunite.loudius.ui.components.LoudiusFullScreenError
 import com.appunite.loudius.ui.components.LoudiusLoadingIndicator
 import com.appunite.loudius.ui.theme.LoudiusTheme
 
@@ -67,7 +67,7 @@ fun AuthenticatingScreenStateless(
 private fun ShowLoudiusLoginErrorScreen(
     onTryAgainClick: () -> Unit,
 ) {
-    LoudiusErrorScreen(
+    LoudiusFullScreenError(
         errorText = stringResource(id = R.string.error_login_text),
         buttonText = stringResource(id = R.string.go_to_login),
         onButtonClick = onTryAgainClick,
@@ -78,7 +78,7 @@ private fun ShowLoudiusLoginErrorScreen(
 private fun ShowLoudiusGenericErrorScreen(
     onTryAgainClick: () -> Unit,
 ) {
-    LoudiusErrorScreen(onButtonClick = onTryAgainClick)
+    LoudiusFullScreenError(onButtonClick = onTryAgainClick)
 }
 
 @Preview(showSystemUi = true)

--- a/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingScreen.kt
@@ -65,12 +65,12 @@ fun AuthenticatingScreenStateless(
 
 @Composable
 private fun ShowLoudiusLoginErrorScreen(
-    onTryAgainClick: () -> Unit,
+    navigateToLogin: () -> Unit,
 ) {
     LoudiusFullScreenError(
         errorText = stringResource(id = R.string.error_login_text),
         buttonText = stringResource(id = R.string.go_to_login),
-        onButtonClick = onTryAgainClick,
+        onButtonClick = navigateToLogin,
     )
 }
 

--- a/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingViewModel.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingViewModel.kt
@@ -28,8 +28,8 @@ import com.appunite.loudius.common.Screen
 import com.appunite.loudius.domain.repository.AuthRepository
 import com.appunite.loudius.network.utils.WebException
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 sealed class AuthenticatingAction {
 
@@ -56,7 +56,7 @@ sealed class AuthenticatingScreenNavigation {
 @HiltViewModel
 class AuthenticatingViewModel @Inject constructor(
     private val authRepository: AuthRepository,
-    private val savedStateHandle: SavedStateHandle,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
     private val code = Screen.Authenticating.getCode(savedStateHandle)

--- a/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingViewModel.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingViewModel.kt
@@ -28,8 +28,8 @@ import com.appunite.loudius.common.Screen
 import com.appunite.loudius.domain.repository.AuthRepository
 import com.appunite.loudius.network.utils.WebException
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 sealed class AuthenticatingAction {
 

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusFullScreenError.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusFullScreenError.kt
@@ -33,12 +33,13 @@ import com.appunite.loudius.ui.theme.LoudiusTheme
 
 @Composable
 fun LoudiusFullScreenError(
+    modifier: Modifier = Modifier,
     errorText: String = stringResource(id = R.string.error_dialog_text),
     buttonText: String = stringResource(id = R.string.try_again),
     onButtonClick: () -> Unit,
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .padding(top = 142.dp)
             .fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusFullScreenError.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusFullScreenError.kt
@@ -32,7 +32,7 @@ import com.appunite.loudius.R
 import com.appunite.loudius.ui.theme.LoudiusTheme
 
 @Composable
-fun LoudiusErrorScreen(
+fun LoudiusFullScreenError(
     errorText: String = stringResource(id = R.string.error_dialog_text),
     buttonText: String = stringResource(id = R.string.try_again),
     onButtonClick: () -> Unit,
@@ -74,7 +74,7 @@ private fun ErrorText(text: String) {
 @Composable
 fun LoudiusErrorScreenPreview() {
     LoudiusTheme {
-        LoudiusErrorScreen(
+        LoudiusFullScreenError(
             errorText = stringResource(id = R.string.error_dialog_text),
             buttonText = stringResource(R.string.try_again),
             onButtonClick = {},

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusLoadingIndicator.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusLoadingIndicator.kt
@@ -34,14 +34,14 @@ import com.appunite.loudius.R
 import com.appunite.loudius.ui.theme.LoudiusTheme
 
 @Composable
-fun LoudiusLoadingIndicator() {
+fun LoudiusLoadingIndicator(modifier: Modifier = Modifier) {
     val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.loading_indicator))
     val progress by animateLottieCompositionAsState(
         composition = composition,
         iterations = LottieConstants.IterateForever,
     )
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
     ) {
         LottieAnimation(
             composition = composition,

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusPlaceholderText.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusPlaceholderText.kt
@@ -18,7 +18,6 @@ package com.appunite.loudius.ui.components
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -31,10 +30,9 @@ import com.appunite.loudius.R
 import com.appunite.loudius.ui.theme.LoudiusTheme
 
 @Composable
-fun LoudiusPlaceholderText(@StringRes textId: Int, padding: PaddingValues) {
+fun LoudiusPlaceholderText(@StringRes textId: Int) {
     Box(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .padding(16.dp),
         contentAlignment = Alignment.Center,
@@ -50,6 +48,6 @@ fun LoudiusPlaceholderText(@StringRes textId: Int, padding: PaddingValues) {
 @Composable
 fun PreviewLoudiusPlaceholderText() {
     LoudiusTheme {
-        LoudiusPlaceholderText(R.string.you_dont_have_any_pull_request, PaddingValues(0.dp))
+        LoudiusPlaceholderText(R.string.you_dont_have_any_pull_request)
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/login/LoginScreen.kt
@@ -33,11 +33,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.appunite.loudius.R
-import com.appunite.loudius.common.Constants.AUTH_API_URL
-import com.appunite.loudius.common.Constants.AUTH_PATH
-import com.appunite.loudius.common.Constants.CLIENT_ID
-import com.appunite.loudius.common.Constants.NAME_PARAM_CLIENT_ID
-import com.appunite.loudius.common.Constants.SCOPE_PARAM
+import com.appunite.loudius.common.Constants.AUTHORIZATION_URL
 import com.appunite.loudius.ui.components.LoudiusOutlinedButton
 import com.appunite.loudius.ui.components.LoudiusOutlinedButtonIcon
 import com.appunite.loudius.ui.components.LoudiusOutlinedButtonStyle
@@ -63,7 +59,7 @@ fun LoginScreen() {
                 )
             },
 
-        )
+            )
     }
 }
 
@@ -78,12 +74,9 @@ fun LoginImage() {
 }
 
 private fun startAuthorizing(context: Context) {
-    val url = buildAuthorizationUrl()
-    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(AUTHORIZATION_URL))
     context.startActivity(intent)
 }
-
-private fun buildAuthorizationUrl() = AUTH_API_URL + AUTH_PATH + NAME_PARAM_CLIENT_ID + CLIENT_ID + SCOPE_PARAM
 
 @Preview(showSystemUi = true, showBackground = true)
 @Composable

--- a/app/src/main/java/com/appunite/loudius/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/login/LoginScreen.kt
@@ -59,7 +59,7 @@ fun LoginScreen() {
                 )
             },
 
-            )
+        )
     }
 }
 

--- a/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
@@ -19,6 +19,7 @@
 package com.appunite.loudius.ui.pullrequests
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -163,10 +164,11 @@ private fun RepoDetails(modifier: Modifier, pullRequestTitle: String, repository
 
 @Composable
 private fun EmptyListPlaceholder(padding: PaddingValues) {
-    LoudiusPlaceholderText(
-        textId = R.string.you_dont_have_any_pull_request,
-        padding = padding,
-    )
+    Box(modifier = Modifier.padding(padding)) {
+        LoudiusPlaceholderText(
+            textId = R.string.you_dont_have_any_pull_request,
+        )
+    }
 }
 
 @Preview("Pull requests - filled list")

--- a/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
@@ -37,7 +37,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.appunite.loudius.R
 import com.appunite.loudius.common.Constants
 import com.appunite.loudius.network.model.PullRequest
-import com.appunite.loudius.ui.components.LoudiusErrorScreen
+import com.appunite.loudius.ui.components.LoudiusFullScreenError
 import com.appunite.loudius.ui.components.LoudiusListIcon
 import com.appunite.loudius.ui.components.LoudiusListItem
 import com.appunite.loudius.ui.components.LoudiusLoadingIndicator
@@ -83,7 +83,7 @@ private fun PullRequestsScreenStateless(
         },
         content = { padding ->
             when {
-                isError -> LoudiusErrorScreen(
+                isError -> LoudiusFullScreenError(
                     onButtonClick = { onAction(PulLRequestsAction.RetryClick) },
                 )
 

--- a/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
@@ -85,10 +85,11 @@ private fun PullRequestsScreenStateless(
         content = { padding ->
             when {
                 isError -> LoudiusFullScreenError(
+                    modifier = Modifier.padding(padding),
                     onButtonClick = { onAction(PulLRequestsAction.RetryClick) },
                 )
 
-                isLoading -> LoudiusLoadingIndicator()
+                isLoading -> LoudiusLoadingIndicator(Modifier.padding(padding))
                 pullRequests.isEmpty() -> EmptyListPlaceholder(padding)
                 else -> PullRequestsList(
                     pullRequests = pullRequests,

--- a/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.appunite.loudius.R
-import com.appunite.loudius.ui.components.LoudiusErrorScreen
+import com.appunite.loudius.ui.components.LoudiusFullScreenError
 import com.appunite.loudius.ui.components.LoudiusListIcon
 import com.appunite.loudius.ui.components.LoudiusListItem
 import com.appunite.loudius.ui.components.LoudiusLoadingIndicator
@@ -125,7 +125,7 @@ private fun ReviewersScreenStateless(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         content = { padding ->
             when {
-                isError -> LoudiusErrorScreen(onButtonClick = { onAction(ReviewersAction.OnTryAgain) })
+                isError -> LoudiusFullScreenError(onButtonClick = { onAction(ReviewersAction.OnTryAgain) })
                 isLoading -> LoudiusLoadingIndicator()
                 reviewers.isEmpty() -> EmptyListPlaceholder(padding)
                 else -> ReviewersScreenContent(

--- a/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
@@ -127,7 +127,7 @@ private fun ReviewersScreenStateless(
             when {
                 isError -> LoudiusFullScreenError(
                     modifier = Modifier.padding(padding),
-                    onButtonClick = { onAction(ReviewersAction.OnTryAgain) }
+                    onButtonClick = { onAction(ReviewersAction.OnTryAgain) },
                 )
                 isLoading -> LoudiusLoadingIndicator(Modifier.padding(padding))
                 reviewers.isEmpty() -> EmptyListPlaceholder(padding)

--- a/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
@@ -231,10 +231,11 @@ private fun ReviewerName(reviewer: Reviewer) {
 
 @Composable
 private fun EmptyListPlaceholder(padding: PaddingValues) {
-    LoudiusPlaceholderText(
-        textId = R.string.you_dont_have_any_reviewers,
-        padding = padding,
-    )
+    Box(modifier = Modifier.padding(padding)) {
+        LoudiusPlaceholderText(
+            textId = R.string.you_dont_have_any_reviewers,
+        )
+    }
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
@@ -125,8 +125,11 @@ private fun ReviewersScreenStateless(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         content = { padding ->
             when {
-                isError -> LoudiusFullScreenError(onButtonClick = { onAction(ReviewersAction.OnTryAgain) })
-                isLoading -> LoudiusLoadingIndicator()
+                isError -> LoudiusFullScreenError(
+                    modifier = Modifier.padding(padding),
+                    onButtonClick = { onAction(ReviewersAction.OnTryAgain) }
+                )
+                isLoading -> LoudiusLoadingIndicator(Modifier.padding(padding))
                 reviewers.isEmpty() -> EmptyListPlaceholder(padding)
                 else -> ReviewersScreenContent(
                     reviewers = reviewers,


### PR DESCRIPTION
## Changes: 
- removed passing the padding values into the `LoudiusPlaceholderText`
- use scaffold's padding in every content composable at the `PullRequestScreen` and `ReviewersScreen`
- renamed LoudiusErrorScreen into LoudiusFullScreenError
- renamed function parameter `onTryAgainClick` into `navigateToLogin` in the `AuthenticatingScreen`


## Screenshots of the issues

![Screenshot 2023-04-06 at 09 18 45](https://user-images.githubusercontent.com/33498031/230303286-cadba79b-4ca8-410e-9455-952ec6b8643f.png)
![Screenshot 2023-04-06 at 09 19 01](https://user-images.githubusercontent.com/33498031/230303345-3d9ff5ce-9b0a-4251-9c8b-f84fa7150aac.png)
![Screenshot 2023-04-06 at 09 28 30](https://user-images.githubusercontent.com/33498031/230305531-df637e3e-2376-4538-963c-6e7d1bbee976.png)
![Screenshot 2023-04-06 at 11 20 09](https://user-images.githubusercontent.com/33498031/230333239-9b1f0c68-0690-46a3-8849-d84271e985d8.png)
