### PR TITLE
[LD-86] Use fake shared preferences for UserLocalDataSourceTest instead of mock

### DIFF
--- a/app/src/test/java/com/appunite/loudius/domain/UserLocalDataSourceTest.kt
+++ b/app/src/test/java/com/appunite/loudius/domain/UserLocalDataSourceTest.kt
@@ -17,46 +17,43 @@
 package com.appunite.loudius.domain
 
 import android.content.Context
-import android.content.SharedPreferences
 import com.appunite.loudius.domain.store.UserLocalDataSourceImpl
+import com.appunite.loudius.fakes.FakeSharedPreferences
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 
 class UserLocalDataSourceTest {
-    private val sharedPreferences = mockk<SharedPreferences>(relaxed = true) {
-        every { getString("access_token", null) } returns "exampleAccessToken"
-    }
+    private val sharedPreferences = FakeSharedPreferences()
     private val context = mockk<Context> {
         every { getSharedPreferences(any(), any()) } returns sharedPreferences
     }
     private val userLocalDataSource = UserLocalDataSourceImpl(context)
 
     @Test
-    fun `GIVEN filled data source WHEN getting access token THEN return access token`() {
+    fun `GIVEN the app is started first time WHEN getting access token THEN token is empty`() {
         val result = userLocalDataSource.getAccessToken()
 
-        expectThat(result).isEqualTo("exampleAccessToken")
-    }
-
-    @Test
-    fun `GIVEN not filled data source WHEN getting access token THEN return empty string`() {
-        every { sharedPreferences.getString("access_token", null) } returns null
-
-        val result = userLocalDataSource.getAccessToken()
         expectThat(result).isEmpty()
     }
 
     @Test
-    fun `GIVEN access token WHEN saving access token THEN shared preferences are edited`() {
-        userLocalDataSource.saveAccessToken("exampleAccessToken")
+    fun `WHEN token is set THEN token can be retrieved`() {
+        userLocalDataSource.saveAccessToken("someToken")
 
-        verify(exactly = 1) {
-            sharedPreferences.edit().putString("access_token", "exampleAccessToken")
-        }
+        val result = userLocalDataSource.getAccessToken()
+        expectThat(result).isEqualTo("someToken")
+    }
+
+    @Test
+    fun `GIVEN token is stored WHEN token is cleared THEN no token to retrieve`() {
+        userLocalDataSource.saveAccessToken("someToken")
+        userLocalDataSource.saveAccessToken("")
+
+        val result = userLocalDataSource.getAccessToken()
+        expectThat(result).isEmpty()
     }
 }

--- a/app/src/test/java/com/appunite/loudius/fakes/FakeSharedPreferences.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakeSharedPreferences.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 AppUnite S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appunite.loudius.fakes
+
+import android.content.SharedPreferences
+
+class FakeSharedPreferences : SharedPreferences {
+
+    private val map = mutableMapOf<String, Any?>()
+
+    private inner class Editor : SharedPreferences.Editor {
+        private val updates = mutableMapOf<String, Any?>()
+
+        override fun putString(key: String, value: String?): SharedPreferences.Editor {
+            updates[key] = value
+            return this
+        }
+
+        override fun putStringSet(
+            key: String,
+            value: MutableSet<String>?
+        ): SharedPreferences.Editor =
+            TODO("Not yet implemented")
+
+        override fun putInt(key: String, value: Int): SharedPreferences.Editor =
+            TODO("Not yet implemented")
+
+        override fun putLong(key: String, value: Long): SharedPreferences.Editor =
+            TODO("Not yet implemented")
+
+        override fun putFloat(key: String, value: Float): SharedPreferences.Editor =
+            TODO("Not yet implemented")
+
+        override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor =
+            TODO("Not yet implemented")
+
+        override fun remove(key: String?): SharedPreferences.Editor = TODO("Not yet implemented")
+
+        override fun clear(): SharedPreferences.Editor = TODO("Not yet implemented")
+
+        override fun commit(): Boolean {
+            apply()
+            return true
+        }
+
+        override fun apply() {
+            map.putAll(updates)
+        }
+    }
+
+    override fun getAll(): MutableMap<String, *> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getString(key: String?, defValue: String?): String? =
+        map[key] as String? ?: defValue
+
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getInt(key: String?, defValue: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLong(key: String?, defValue: Long): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getFloat(key: String?, defValue: Float): Float {
+        TODO("Not yet implemented")
+    }
+
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun contains(key: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun edit(): SharedPreferences.Editor = Editor()
+
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/test/java/com/appunite/loudius/fakes/FakeSharedPreferences.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakeSharedPreferences.kt
@@ -32,7 +32,7 @@ class FakeSharedPreferences : SharedPreferences {
 
         override fun putStringSet(
             key: String,
-            value: MutableSet<String>?
+            value: MutableSet<String>?,
         ): SharedPreferences.Editor =
             TODO("Not yet implemented")
 


### PR DESCRIPTION
## Changes: 
- used fake shared preferences for UserLocalDataSourceTest instead of mock

## Why: 
To improve the code proposed by suggestion in #59 