### PR TITLE
Better mock-web-server

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,6 +119,7 @@ dependencies {
     testImplementation 'io.strikt:strikt-core:0.33.0'
     testImplementation 'io.strikt:strikt-mockk:0.33.0'
     androidTestImplementation 'io.strikt:strikt-core:0.33.0'
+    androidTestImplementation 'io.strikt:strikt-mockk:0.33.0'
 
     //testing
     testImplementation "io.mockk:mockk:1.13.3"

--- a/app/src/androidTest/java/com/appunite/loudius/PullRequestsScreenTest.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/PullRequestsScreenTest.kt
@@ -59,7 +59,6 @@ class PullRequestsScreenTest {
 
     @Test
     fun whenResponseIsCorrectThenPullRequestItemIsVisible() {
-
         mockWebServer.register {
             expectThat(it).url.path.isEqualTo("/user")
 

--- a/app/src/androidTest/java/com/appunite/loudius/PullRequestsScreenTest.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/PullRequestsScreenTest.kt
@@ -155,7 +155,7 @@ class PullRequestsScreenTest {
                                 }
                             ]
                         }
-                    """
+                    """,
             )
         }
 

--- a/app/src/androidTest/java/com/appunite/loudius/PullRequestsScreenTest.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/PullRequestsScreenTest.kt
@@ -24,133 +24,145 @@ import com.appunite.loudius.ui.pullrequests.PullRequestsScreen
 import com.appunite.loudius.ui.theme.LoudiusTheme
 import com.appunite.loudius.util.MockWebServerRule
 import com.appunite.loudius.util.jsonResponse
-import com.appunite.loudius.util.matchArg
 import com.appunite.loudius.util.path
+import com.appunite.loudius.util.queryParameter
+import com.appunite.loudius.util.url
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import io.mockk.every
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import strikt.api.expectThat
 import strikt.assertions.isEqualTo
-import strikt.assertions.startsWith
 import java.lang.Thread.sleep
 
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
 class PullRequestsScreenTest {
 
-    @get:Rule(order = 0)
+    @get:Rule(order = 1)
     val hiltRule = HiltAndroidRule(this)
 
-    @get:Rule
+    @get:Rule(order = 0)
     var mockWebServer: MockWebServerRule = MockWebServerRule()
 
-    @get:Rule(order = 1)
+    @get:Rule(order = 2)
     val composeTestRule = createAndroidComposeRule<TestActivity>()
 
     @Before
     fun setUp() {
         hiltRule.inject()
+    }
+
+    @Test
+    fun whenResponseIsCorrectThenPullRequestItemIsVisible() {
+
+        mockWebServer.register {
+            expectThat(it).url.path.isEqualTo("/user")
+
+            jsonResponse("""{"id": 1, "login": "jacek"}""")
+        }
+
+        mockWebServer.register {
+            expectThat(it).url.and {
+                get("host") { host }.isEqualTo("api.github.com")
+                path.isEqualTo("/search/issues")
+                queryParameter("q").isEqualTo("author:jacek type:pr state:open")
+                queryParameter("page").isEqualTo("0")
+                queryParameter("per_page").isEqualTo("100")
+            }
+
+            jsonResponse(
+                """
+                        {
+                            "total_count":1,
+                            "incomplete_results":false,
+                            "items":[
+                                {
+                                    "url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1",
+                                    "repository_url":"https://api.github.com/repos/exampleOwner/exampleRepo",
+                                    "labels_url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/labels{/name}",
+                                    "comments_url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/comments",
+                                    "events_url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/events",
+                                    "html_url":"https://github.com/exampleOwner/exampleRepo/pull/1",
+                                    "id":1,
+                                    "node_id":"example_node_id",
+                                    "number":1,
+                                    "title":"First Pull-Request title",
+                                    "user":{
+                                        "login":"exampleUser",
+                                        "id":1,
+                                        "node_id":"example_user_node_id",
+                                        "avatar_url":"https://avatars.githubusercontent.com/u/1",
+                                        "gravatar_id":"",
+                                        "url":"https://api.github.com/users/exampleUser",
+                                        "html_url":"https://github.com/exampleUser",
+                                        "followers_url":"https://api.github.com/users/exampleUser/followers",
+                                        "following_url":"https://api.github.com/users/exampleUser/following{/other_user}",
+                                        "gists_url":"https://api.github.com/users/exampleUser/gists{/gist_id}",
+                                        "starred_url":"https://api.github.com/users/exampleUser/starred{/owner}{/repo}",
+                                        "subscriptions_url":"https://api.github.com/users/exampleUser/subscriptions",
+                                        "organizations_url":"https://api.github.com/users/exampleUser/orgs",
+                                        "repos_url":"https://api.github.com/users/exampleUser/repos",
+                                        "events_url":"https://api.github.com/users/exampleUser/events{/privacy}",
+                                        "received_events_url":"https://api.github.com/users/exampleUser/received_events",
+                                        "type":"User",
+                                        "site_admin":false
+                                    },
+                                    "labels":[
+                                        
+                                    ],
+                                    "state":"open",
+                                    "locked":false,
+                                    "assignee":null,
+                                    "assignees":[
+                                        
+                                    ],
+                                    "milestone":null,
+                                    "comments":1,
+                                    "created_at":"2023-03-07T09:21:45Z",
+                                    "updated_at":"2023-03-07T09:24:24Z",
+                                    "closed_at":null,
+                                    "author_association":"COLLABORATOR",
+                                    "active_lock_reason":null,
+                                    "draft":false,
+                                    "pull_request":{
+                                        "url":"https://api.github.com/repos/exampleOwner/exampleRepo/pulls/1",
+                                        "html_url":"https://github.com/exampleOwner/exampleRepo/pull/1",
+                                        "diff_url":"https://github.com/exampleOwner/exampleRepo/pull/1.diff",
+                                        "patch_url":"https://github.com/exampleOwner/exampleRepo/pull/1.patch",
+                                        "merged_at":null
+                                    },
+                                    "body":"pr only for demonstration purposes  . . . .",
+                                    "reactions":{
+                                        "url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/reactions",
+                                        "total_count":0,
+                                        "+1":0,
+                                        "-1":0,
+                                        "laugh":0,
+                                        "hooray":0,
+                                        "confused":0,
+                                        "heart":0,
+                                        "rocket":0,
+                                        "eyes":0
+                                    },
+                                    "timeline_url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/timeline",
+                                    "performed_via_github_app":null,
+                                    "state_reason":null,
+                                    "score":1.0
+                                }
+                            ]
+                        }
+                    """
+            )
+        }
+
         composeTestRule.setContent {
             LoudiusTheme {
                 PullRequestsScreen { _, _, _, _ -> }
             }
         }
-    }
-
-    @Test
-    fun whenResponseIsCorrectThenPullRequestItemIsVisible() {
-        every {
-            mockWebServer.dispatcher.dispatch(matchArg { path.isEqualTo("/user") })
-        } returns jsonResponse("{\"id\": 1, \"login\": \"user\"}")
-
-        val jsonResponse = """
-                {
-                    "total_count":1,
-                    "incomplete_results":false,
-                    "items":[
-                        {
-                            "url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1",
-                            "repository_url":"https://api.github.com/repos/exampleOwner/exampleRepo",
-                            "labels_url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/labels{/name}",
-                            "comments_url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/comments",
-                            "events_url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/events",
-                            "html_url":"https://github.com/exampleOwner/exampleRepo/pull/1",
-                            "id":1,
-                            "node_id":"example_node_id",
-                            "number":1,
-                            "title":"First Pull-Request title",
-                            "user":{
-                                "login":"exampleUser",
-                                "id":1,
-                                "node_id":"example_user_node_id",
-                                "avatar_url":"https://avatars.githubusercontent.com/u/1",
-                                "gravatar_id":"",
-                                "url":"https://api.github.com/users/exampleUser",
-                                "html_url":"https://github.com/exampleUser",
-                                "followers_url":"https://api.github.com/users/exampleUser/followers",
-                                "following_url":"https://api.github.com/users/exampleUser/following{/other_user}",
-                                "gists_url":"https://api.github.com/users/exampleUser/gists{/gist_id}",
-                                "starred_url":"https://api.github.com/users/exampleUser/starred{/owner}{/repo}",
-                                "subscriptions_url":"https://api.github.com/users/exampleUser/subscriptions",
-                                "organizations_url":"https://api.github.com/users/exampleUser/orgs",
-                                "repos_url":"https://api.github.com/users/exampleUser/repos",
-                                "events_url":"https://api.github.com/users/exampleUser/events{/privacy}",
-                                "received_events_url":"https://api.github.com/users/exampleUser/received_events",
-                                "type":"User",
-                                "site_admin":false
-                            },
-                            "labels":[
-                                
-                            ],
-                            "state":"open",
-                            "locked":false,
-                            "assignee":null,
-                            "assignees":[
-                                
-                            ],
-                            "milestone":null,
-                            "comments":1,
-                            "created_at":"2023-03-07T09:21:45Z",
-                            "updated_at":"2023-03-07T09:24:24Z",
-                            "closed_at":null,
-                            "author_association":"COLLABORATOR",
-                            "active_lock_reason":null,
-                            "draft":false,
-                            "pull_request":{
-                                "url":"https://api.github.com/repos/exampleOwner/exampleRepo/pulls/1",
-                                "html_url":"https://github.com/exampleOwner/exampleRepo/pull/1",
-                                "diff_url":"https://github.com/exampleOwner/exampleRepo/pull/1.diff",
-                                "patch_url":"https://github.com/exampleOwner/exampleRepo/pull/1.patch",
-                                "merged_at":null
-                            },
-                            "body":"pr only for demonstration purposes  . . . .",
-                            "reactions":{
-                                "url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/reactions",
-                                "total_count":0,
-                                "+1":0,
-                                "-1":0,
-                                "laugh":0,
-                                "hooray":0,
-                                "confused":0,
-                                "heart":0,
-                                "rocket":0,
-                                "eyes":0
-                            },
-                            "timeline_url":"https://api.github.com/repos/exampleOwner/exampleRepo/issues/1/timeline",
-                            "performed_via_github_app":null,
-                            "state_reason":null,
-                            "score":1.0
-                        }
-                    ]
-                }
-        """.trimIndent()
-
-        every {
-            mockWebServer.dispatcher.dispatch(matchArg { path.startsWith("/search/issues") })
-        } returns jsonResponse(jsonResponse)
 
         sleep(3000) // Temporary solution
         composeTestRule.onNodeWithText("First Pull-Request title").assertIsDisplayed()

--- a/app/src/androidTest/java/com/appunite/loudius/util/Assertions.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/Assertions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 AppUnite S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.appunite.loudius.util
 
 import okhttp3.Headers

--- a/app/src/androidTest/java/com/appunite/loudius/util/Assertions.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/Assertions.kt
@@ -10,15 +10,19 @@ import strikt.assertions.isNotNull
 
 inline val Assertion.Builder<Request>.url: Assertion.Builder<HttpUrl> get() = get(Request::url)
 inline val Assertion.Builder<Request>.method: Assertion.Builder<String> get() = get(Request::method)
+
 @get:JvmName("requestBody")
 inline val Assertion.Builder<Request>.body: Assertion.Builder<Buffer> get() = get(Request::body)
 inline val Assertion.Builder<Buffer>.utf8: Assertion.Builder<String> get() = get("utf8 string") { readUtf8() }
+
 @get:JvmName("requestHeaders")
 inline val Assertion.Builder<Request>.headers: Assertion.Builder<Headers> get() = get(Request::headers)
 inline val Assertion.Builder<Response>.code: Assertion.Builder<Int> get() = get("code") { code }
+
 @get:JvmName("responseBody")
 inline val Assertion.Builder<Response>.body: Assertion.Builder<ResponseBody?> get() = get("body") { body }
 inline val Assertion.Builder<Response>.bodyString: Assertion.Builder<String> get() = body.isNotNull().get("utf8") { string() }
+
 @get:JvmName("responseHeaders")
 inline val Assertion.Builder<Response>.headers: Assertion.Builder<Headers> get() = get("headers") { headers }
 inline fun Assertion.Builder<Headers>.header(name: String): Assertion.Builder<String?> = get("header $name") { get(name) }

--- a/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRule.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRule.kt
@@ -39,7 +39,7 @@ class Request(
     val headers: Headers,
     val method: String,
     val url: HttpUrl,
-    val body: Buffer
+    val body: Buffer,
 ) {
     override fun toString(): String =
         "Request(method=$method, url=$url, headers=${headers.joinToString(separator = ",") { (key, value) -> "$key: $value" }})"
@@ -73,7 +73,7 @@ class MockWebServerRule : TestRule {
                                 buildList {
                                     add(e)
                                     addAll(dispatcher.errors)
-                                }
+                                },
                             )
                         }
                     } finally {
@@ -100,7 +100,7 @@ private class UrlOverrideInterceptor(private val baseUrl: HttpUrl) : Interceptor
             .build()
         return chain.proceed(
             request.newBuilder().url(newUrl)
-                .addHeader("X-Test-Original-Url", request.url.toString()).build()
+                .addHeader("X-Test-Original-Url", request.url.toString()).build(),
         )
     }
 }
@@ -130,7 +130,7 @@ private class MockDispatcher : Dispatcher() {
                         ).toHttpUrl(),
                     headers = request.headers.newBuilder().removeAll("X-Test-Original-Url").build(),
                     method = request.method ?: throw Exception("Nullable method in the request"),
-                    body = request.body
+                    body = request.body,
                 )
             } catch (e: Exception) {
                 throw Exception("Request: $request, is incorrect", e)
@@ -155,7 +155,7 @@ private class MockDispatcher : Dispatcher() {
         }
         throw MultipleFailuresError(
             "Request: ${mockRequest.method} ${mockRequest.url}, " + if (assertionErrors.isEmpty()) "there are no mocks" else "no mock is matching the request",
-            assertionErrors
+            assertionErrors,
         )
     }
 }
@@ -176,7 +176,7 @@ class MultipleFailuresError(val heading: String, val failures: List<Throwable>) 
                     0 -> "no failures"
                     1 -> "failure"
                     else -> "failures"
-                }
+                },
             )
             append(")")
             append("\n")

--- a/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRule.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRule.kt
@@ -35,12 +35,11 @@ import org.junit.runners.model.Statement
 
 private const val TAG = "MockWebServerRule"
 
-
 class Request(
     val headers: Headers,
     val method: String,
     val url: HttpUrl,
-    val body: Buffer,
+    val body: Buffer
 ) {
     override fun toString(): String =
         "Request(method=$method, url=$url, headers=${headers.joinToString(separator = ",") { (key, value) -> "$key: $value" }})"
@@ -74,7 +73,8 @@ class MockWebServerRule : TestRule {
                                 buildList {
                                     add(e)
                                     addAll(dispatcher.errors)
-                                })
+                                }
+                            )
                         }
                     } finally {
                         Log.v(TAG, "TestInterceptor uninstalled")
@@ -90,7 +90,6 @@ fun jsonResponse(@Language("JSON") json: String): MockResponse = MockResponse()
     .addHeader("Content-Type", "application/json")
     .setBody(json.trimIndent())
 
-
 private class UrlOverrideInterceptor(private val baseUrl: HttpUrl) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
@@ -101,7 +100,7 @@ private class UrlOverrideInterceptor(private val baseUrl: HttpUrl) : Interceptor
             .build()
         return chain.proceed(
             request.newBuilder().url(newUrl)
-                .addHeader("X-Test-Original-Url", request.url.toString()).build(),
+                .addHeader("X-Test-Original-Url", request.url.toString()).build()
         )
     }
 }
@@ -125,11 +124,13 @@ private class MockDispatcher : Dispatcher() {
         try {
             val mockRequest = try {
                 Request(
-                    url = (request.getHeader("X-Test-Original-Url")
-                        ?: throw Exception("No X-Test-Original-Url header, problem with mocker")).toHttpUrl(),
+                    url = (
+                        request.getHeader("X-Test-Original-Url")
+                            ?: throw Exception("No X-Test-Original-Url header, problem with mocker")
+                        ).toHttpUrl(),
                     headers = request.headers.newBuilder().removeAll("X-Test-Original-Url").build(),
                     method = request.method ?: throw Exception("Nullable method in the request"),
-                    body = request.body,
+                    body = request.body
                 )
             } catch (e: Exception) {
                 throw Exception("Request: $request, is incorrect", e)
@@ -185,8 +186,6 @@ class MultipleFailuresError(val heading: String, val failures: List<Throwable>) 
             }
         }
 
-
     private fun nullSafeMessage(failure: Throwable): String =
         failure.javaClass.name + ": " + failure.message.orEmpty().ifBlank { "<no message>" }
-
 }

--- a/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRuleTest.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRuleTest.kt
@@ -95,7 +95,7 @@ class MockWebServerRuleTest {
                     .contains("An test exception occurred, but we also found some not mocked requests")
                 expectThat(it).isA<MultipleFailuresError>().get(MultipleFailuresError::failures)
                     .first().isA<CustomException>()
-            }
+            },
         )
 
         executeRequest("https://example.com/not_mocked")
@@ -120,7 +120,7 @@ class MockWebServerRuleTest {
                             .contains("Request: GET https://example.com/not_mocked, there are no mocks")
                         get(MultipleFailuresError::failures).isEmpty()
                     }
-            }
+            },
         )
 
         executeRequest("https://example.com/not_mocked")
@@ -158,7 +158,7 @@ class MockWebServerRuleTest {
                                 message.isNotNull().contains("found \"/not_mocked\"")
                             }
                     }
-            }
+            },
         )
 
         executeRequest("https://example.com/not_mocked")
@@ -214,7 +214,7 @@ class MockWebServerRuleTest {
         val slot = executeRequestAndGetMockedArgumentRequest {
             it.method(
                 "POST",
-                "Request body".toRequestBody()
+                "Request body".toRequestBody(),
             )
         }
 
@@ -229,7 +229,7 @@ class MockWebServerRuleTest {
         expectedException.expect(
             matcher<Any> {
                 expectThat(it).isA<CustomException>()
-            }
+            },
         )
 
         throw CustomException
@@ -237,21 +237,21 @@ class MockWebServerRuleTest {
 
     private fun executeRequest(
         url: String,
-        builder: (okhttp3.Request.Builder) -> okhttp3.Request.Builder = { it }
+        builder: (okhttp3.Request.Builder) -> okhttp3.Request.Builder = { it },
     ): Response {
         val client = OkHttpClient.Builder()
             .addInterceptor(TestInterceptor)
             .build()
         val request = builder(
             okhttp3.Request.Builder()
-                .url(url)
+                .url(url),
         )
             .build()
         return client.newCall(request).execute()
     }
 
     private fun executeRequestAndGetMockedArgumentRequest(
-        requestBuilder: (okhttp3.Request.Builder) -> okhttp3.Request.Builder = { it }
+        requestBuilder: (okhttp3.Request.Builder) -> okhttp3.Request.Builder = { it },
     ): CapturingSlot<Request> {
         val slot = slot<Request>()
         val mock = mockk<ResponseGenerator> {

--- a/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRuleTest.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRuleTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 AppUnite S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.appunite.loudius.util
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRuleTest.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRuleTest.kt
@@ -89,36 +89,39 @@ class MockWebServerRuleTest {
 
     @Test
     fun testTestFailsAndThereIsSomeMockingIssue_theRootOfTheFailureIsOnTheFirstPlace() {
-        expectedException.expect(matcher<Any> {
-            expectThat(it).isA<MultipleFailuresError>().message.isNotNull()
-                .contains("An test exception occurred, but we also found some not mocked requests")
-            expectThat(it).isA<MultipleFailuresError>().get(MultipleFailuresError::failures)
-                .first().isA<CustomException>()
-        })
+        expectedException.expect(
+            matcher<Any> {
+                expectThat(it).isA<MultipleFailuresError>().message.isNotNull()
+                    .contains("An test exception occurred, but we also found some not mocked requests")
+                expectThat(it).isA<MultipleFailuresError>().get(MultipleFailuresError::failures)
+                    .first().isA<CustomException>()
+            }
+        )
 
         executeRequest("https://example.com/not_mocked")
 
         throw CustomException
     }
 
-
     @Test
     fun testTestFailsAndThereIsSomeMockingIssue_returnInformationAboutExceptionAndNotMockedResponses() {
-        expectedException.expect(matcher<Any> {
-            expectThat(it).isA<Throwable>().message.isNotNull()
-                .contains("Request: GET https://example.com/not_mocked, there are no mocks")
+        expectedException.expect(
+            matcher<Any> {
+                expectThat(it).isA<Throwable>().message.isNotNull()
+                    .contains("Request: GET https://example.com/not_mocked, there are no mocks")
 
-            expectThat(it)
-                .isA<MultipleFailuresError>()
-                .get(MultipleFailuresError::failures)
-                .last()
-                .isA<MultipleFailuresError>()
-                .and {
-                    message.isNotNull()
-                        .contains("Request: GET https://example.com/not_mocked, there are no mocks")
-                    get(MultipleFailuresError::failures).isEmpty()
-                }
-        })
+                expectThat(it)
+                    .isA<MultipleFailuresError>()
+                    .get(MultipleFailuresError::failures)
+                    .last()
+                    .isA<MultipleFailuresError>()
+                    .and {
+                        message.isNotNull()
+                            .contains("Request: GET https://example.com/not_mocked, there are no mocks")
+                        get(MultipleFailuresError::failures).isEmpty()
+                    }
+            }
+        )
 
         executeRequest("https://example.com/not_mocked")
 
@@ -132,36 +135,36 @@ class MockWebServerRuleTest {
 
             MockResponse().setBody("Hello, World!")
         }
-        expectedException.expect(matcher<Any> {
-            expectThat(it).isA<Throwable>().message.isNotNull().and {
-                contains("Request: GET https://example.com/not_mocked, no mock is matching the request")
-                contains("✗ is equal to \"/different_url\"")
-                contains("found \"/not_mocked\"")
-            }
-
-            expectThat(it)
-                .isA<MultipleFailuresError>()
-                .get(MultipleFailuresError::failures)
-                .last()
-                .isA<MultipleFailuresError>()
-                .and {
-                    message.isNotNull()
-                        .contains("Request: GET https://example.com/not_mocked, no mock is matching the request")
-                    get(MultipleFailuresError::failures)
-                        .single()
-                        .isA<AssertionError>().and {
-                            message.isNotNull().contains("✗ is equal to \"/different_url\"")
-                            message.isNotNull().contains("found \"/not_mocked\"")
-
-                        }
+        expectedException.expect(
+            matcher<Any> {
+                expectThat(it).isA<Throwable>().message.isNotNull().and {
+                    contains("Request: GET https://example.com/not_mocked, no mock is matching the request")
+                    contains("✗ is equal to \"/different_url\"")
+                    contains("found \"/not_mocked\"")
                 }
-        })
+
+                expectThat(it)
+                    .isA<MultipleFailuresError>()
+                    .get(MultipleFailuresError::failures)
+                    .last()
+                    .isA<MultipleFailuresError>()
+                    .and {
+                        message.isNotNull()
+                            .contains("Request: GET https://example.com/not_mocked, no mock is matching the request")
+                        get(MultipleFailuresError::failures)
+                            .single()
+                            .isA<AssertionError>().and {
+                                message.isNotNull().contains("✗ is equal to \"/different_url\"")
+                                message.isNotNull().contains("found \"/not_mocked\"")
+                            }
+                    }
+            }
+        )
 
         executeRequest("https://example.com/not_mocked")
 
         throw CustomException
     }
-
 
     @Test
     fun testWhenRequestUrlIsDifferentThenMocked_throw404() {
@@ -223,9 +226,11 @@ class MockWebServerRuleTest {
 
     @Test
     fun whenExceptionIsThrown_passIt() {
-        expectedException.expect(matcher<Any> {
-            expectThat(it).isA<CustomException>()
-        })
+        expectedException.expect(
+            matcher<Any> {
+                expectThat(it).isA<CustomException>()
+            }
+        )
 
         throw CustomException
     }

--- a/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRuleTest.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/MockWebServerRuleTest.kt
@@ -1,0 +1,293 @@
+package com.appunite.loudius.util
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.appunite.loudius.di.TestInterceptor
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.mockwebserver.MockResponse
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.first
+import strikt.assertions.isA
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.last
+import strikt.assertions.message
+import strikt.assertions.single
+import strikt.mockk.captured
+
+@RunWith(AndroidJUnit4::class)
+class MockWebServerRuleTest {
+
+    @Suppress("DEPRECATION")
+    @get:Rule(order = 0)
+    val expectedException: ExpectedException = ExpectedException.none()
+
+    @get:Rule(order = 1)
+    val mockWebServerRule: MockWebServerRule = MockWebServerRule()
+
+    @Test
+    fun testWhenRequestIsMocked_requestReturnsItsValue() {
+        mockWebServerRule.register { _ ->
+            MockResponse().setBody("Hello, World!")
+        }
+
+        val response = executeRequest("https://example.com/user")
+
+        expectThat(response).and {
+            code.isEqualTo(200)
+            bodyString.isEqualTo("Hello, World!")
+        }
+    }
+
+    @Test
+    fun testWhenJsonIsMocked_requestReturnsItsValueAndCorrectHeaders() {
+        mockWebServerRule.register { _ ->
+            jsonResponse("""{"krowa": "pies"}""")
+        }
+
+        val response = executeRequest("https://example.com/user")
+
+        expectThat(response).and {
+            code.isEqualTo(200)
+            headers.header("Content-Type").isEqualTo("application/json")
+            bodyString.isEqualTo("""{"krowa": "pies"}""")
+        }
+    }
+
+    @Test
+    fun testWhenMockIsCleared_requestGetsDefault404() {
+        mockWebServerRule.register { _ ->
+            MockResponse().setBody("Hello, World!")
+        }
+
+        mockWebServerRule.clear()
+
+        val response = executeRequest("https://example.com/user")
+        expectThat(response).code.isEqualTo(404)
+    }
+
+    @Test
+    fun testWhenNoRequestIsMocked_throw404() {
+        val response = executeRequest("https://example.com/not_mocked")
+
+        expectThat(response).code.isEqualTo(404)
+    }
+
+    @Test
+    fun testTestFailsAndThereIsSomeMockingIssue_theRootOfTheFailureIsOnTheFirstPlace() {
+        expectedException.expect(matcher<Any> {
+            expectThat(it).isA<MultipleFailuresError>().message.isNotNull()
+                .contains("An test exception occurred, but we also found some not mocked requests")
+            expectThat(it).isA<MultipleFailuresError>().get(MultipleFailuresError::failures)
+                .first().isA<CustomException>()
+        })
+
+        executeRequest("https://example.com/not_mocked")
+
+        throw CustomException
+    }
+
+
+    @Test
+    fun testTestFailsAndThereIsSomeMockingIssue_returnInformationAboutExceptionAndNotMockedResponses() {
+        expectedException.expect(matcher<Any> {
+            expectThat(it).isA<Throwable>().message.isNotNull()
+                .contains("Request: GET https://example.com/not_mocked, there are no mocks")
+
+            expectThat(it)
+                .isA<MultipleFailuresError>()
+                .get(MultipleFailuresError::failures)
+                .last()
+                .isA<MultipleFailuresError>()
+                .and {
+                    message.isNotNull()
+                        .contains("Request: GET https://example.com/not_mocked, there are no mocks")
+                    get(MultipleFailuresError::failures).isEmpty()
+                }
+        })
+
+        executeRequest("https://example.com/not_mocked")
+
+        throw CustomException
+    }
+
+    @Test
+    fun testTestFailsAndThereIsSomeMockingIssue_listAllUnmatchedRequests() {
+        mockWebServerRule.register {
+            expectThat(it).url.path.isEqualTo("/different_url")
+
+            MockResponse().setBody("Hello, World!")
+        }
+        expectedException.expect(matcher<Any> {
+            expectThat(it).isA<Throwable>().message.isNotNull().and {
+                contains("Request: GET https://example.com/not_mocked, no mock is matching the request")
+                contains("✗ is equal to \"/different_url\"")
+                contains("found \"/not_mocked\"")
+            }
+
+            expectThat(it)
+                .isA<MultipleFailuresError>()
+                .get(MultipleFailuresError::failures)
+                .last()
+                .isA<MultipleFailuresError>()
+                .and {
+                    message.isNotNull()
+                        .contains("Request: GET https://example.com/not_mocked, no mock is matching the request")
+                    get(MultipleFailuresError::failures)
+                        .single()
+                        .isA<AssertionError>().and {
+                            message.isNotNull().contains("✗ is equal to \"/different_url\"")
+                            message.isNotNull().contains("found \"/not_mocked\"")
+
+                        }
+                }
+        })
+
+        executeRequest("https://example.com/not_mocked")
+
+        throw CustomException
+    }
+
+
+    @Test
+    fun testWhenRequestUrlIsDifferentThenMocked_throw404() {
+        mockWebServerRule.register {
+            expectThat(it).url.path.isEqualTo("/different_url")
+
+            MockResponse().setBody("Hello, World!")
+        }
+
+        val response = executeRequest("https://example.com/not_mocked")
+
+        expectThat(response).code.isEqualTo(404)
+    }
+
+    @Test
+    fun testWhenRequestIsMade_passedUrlAndMethodAreCorrect() {
+        val slot = slot<Request>()
+        val mock = mockk<ResponseGenerator> {
+            every { this@mockk.invoke(capture(slot)) } returns MockResponse().setBody("Hello, World!")
+        }
+        mockWebServerRule.register(mock)
+
+        executeRequest("https://example.com/url") { it.addHeader("Accept", "application/json") }
+
+        expectThat(slot).captured.and {
+            url.path.isEqualTo("/url")
+            url.host.isEqualTo("example.com")
+            method.isEqualTo("GET")
+        }
+    }
+
+    @Test
+    fun testWhenRequestIsMadeWithHeader_passedRequestHasHeaderSet() {
+        val slot = slot<Request>()
+        val mock = mockk<ResponseGenerator> {
+            every { this@mockk.invoke(capture(slot)) } returns MockResponse().setBody("Hello, World!")
+        }
+        mockWebServerRule.register(mock)
+
+        executeRequest("https://example.com/url") { it.addHeader("Accept", "application/json") }
+
+        expectThat(slot).captured.headers.header("Accept").isEqualTo("application/json")
+    }
+
+    @Test
+    fun testWhenGetRequestIsMade_bodyIsEmpty() {
+        val slot = slot<Request>()
+        val mock = mockk<ResponseGenerator> {
+            every { this@mockk.invoke(capture(slot)) } returns MockResponse().setBody("Hello, World!")
+        }
+        mockWebServerRule.register(mock)
+
+        executeRequest("https://example.com/url")
+
+        expectThat(slot).captured.and {
+            body.utf8.isEmpty()
+            method.isEqualTo("GET")
+        }
+    }
+
+    @Test
+    fun testWhenPostRequestIsMade_bodyIsSet() {
+        val slot = slot<Request>()
+        val mock = mockk<ResponseGenerator> {
+            every { this@mockk.invoke(capture(slot)) } returns MockResponse().setBody("Hello, World!")
+        }
+        mockWebServerRule.register(mock)
+
+        executeRequest("https://example.com/url") {
+            it.method(
+                "POST",
+                "Request body".toRequestBody()
+            )
+        }
+
+        expectThat(slot).captured.and {
+            body.utf8.isEqualTo("Request body")
+            method.isEqualTo("POST")
+        }
+    }
+
+    @Test
+    fun whenExceptionIsThrown_passIt() {
+        expectedException.expect(matcher<Any> {
+            expectThat(it).isA<CustomException>()
+        })
+
+        throw CustomException
+    }
+
+    private fun executeRequest(
+        url: String,
+        builder: (okhttp3.Request.Builder) -> okhttp3.Request.Builder = { it }
+    ): Response {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(TestInterceptor)
+            .build()
+        val request = builder(
+            okhttp3.Request.Builder()
+                .url(url)
+        )
+            .build()
+        return client.newCall(request).execute()
+    }
+}
+
+private object CustomException : Exception("Custom exception")
+
+private fun <T> matcher(check: (T) -> Unit): Matcher<T> = object : TypeSafeMatcher<T>() {
+    override fun describeTo(description: Description) {}
+
+    override fun describeMismatchSafely(item: T, description: Description) {
+        try {
+            check(item)
+        } catch (e: AssertionError) {
+            description.appendText(e.message)
+            return
+        }
+        throw RuntimeException("Something went wrong... exception should happen")
+    }
+
+    override fun matchesSafely(item: T): Boolean {
+        return try {
+            check(item)
+            true
+        } catch (e: AssertionError) {
+            false
+        }
+    }
+}

--- a/app/src/androidTest/java/com/appunite/loudius/util/assertions.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/assertions.kt
@@ -1,0 +1,29 @@
+package com.appunite.loudius.util
+
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okio.Buffer
+import strikt.api.Assertion
+import strikt.assertions.isNotNull
+
+inline val Assertion.Builder<Request>.url: Assertion.Builder<HttpUrl> get() = get(Request::url)
+inline val Assertion.Builder<Request>.method: Assertion.Builder<String> get() = get(Request::method)
+@get:JvmName("requestBody")
+inline val Assertion.Builder<Request>.body: Assertion.Builder<Buffer> get() = get(Request::body)
+inline val Assertion.Builder<Buffer>.utf8: Assertion.Builder<String> get() = get("utf8 string") { readUtf8() }
+@get:JvmName("requestHeaders")
+inline val Assertion.Builder<Request>.headers: Assertion.Builder<Headers> get() = get(Request::headers)
+inline val Assertion.Builder<Response>.code: Assertion.Builder<Int> get() = get("code") { code }
+@get:JvmName("responseBody")
+inline val Assertion.Builder<Response>.body: Assertion.Builder<ResponseBody?> get() = get("body") { body }
+inline val Assertion.Builder<Response>.bodyString: Assertion.Builder<String> get() = body.isNotNull().get("utf8") { string() }
+@get:JvmName("responseHeaders")
+inline val Assertion.Builder<Response>.headers: Assertion.Builder<Headers> get() = get("headers") { headers }
+inline fun Assertion.Builder<Headers>.header(name: String): Assertion.Builder<String?> = get("header $name") { get(name) }
+inline val Assertion.Builder<HttpUrl>.path: Assertion.Builder<String> get() = get("path") { this.encodedPath }
+inline val Assertion.Builder<HttpUrl>.host: Assertion.Builder<String> get() = get("host") { this.host }
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun Assertion.Builder<HttpUrl>.queryParameter(name: String): Assertion.Builder<String?> = get("query parameter \"$name\"") { this.queryParameter(name) }

--- a/app/src/main/java/com/appunite/loudius/network/model/error/DefaultErrorResponse.kt
+++ b/app/src/main/java/com/appunite/loudius/network/model/error/DefaultErrorResponse.kt
@@ -17,6 +17,6 @@
 package com.appunite.loudius.network.model.error
 
 data class DefaultErrorResponse(
-    val message: String,
-    val documentationUrl: String,
+    val message: String?,
+    val documentationUrl: String?,
 )

--- a/app/src/main/java/com/appunite/loudius/network/utils/ApiRequester.kt
+++ b/app/src/main/java/com/appunite/loudius/network/utils/ApiRequester.kt
@@ -44,11 +44,11 @@ class ApiRequester @Inject constructor(private val gson: Gson) {
     }
 
     private fun getApiErrorMessageIfExist(throwable: HttpException) = try {
-        val errorResponse = gson.fromJson(
+        val errorResponse: DefaultErrorResponse? = gson.fromJson(
             throwable.response()?.errorBody()?.charStream(),
             DefaultErrorResponse::class.java,
         )
-        errorResponse.message
+        errorResponse?.message
     } catch (throwable: JSONException) {
         null
     }


### PR DESCRIPTION
#Why?
Currently, when writing UI tests, we forget to add an HTTP mock for a given request. We will get test failure with information that a given view can't be found. Then we will need to manually find why a given problem occurred. Of course, we can try to look for logs for a given problem, but looking through logs is time-consuming, and we spend time looking for an issue in completely wrong place. Wouldn't be nice to get information that we've forgotten to mock HTTP response? 
Moreover, from time to time instead of mocking `GET /users` we mock `GET /user`. Wouldn't be nice if the tool would say us, what was mocked, and why given mock didn't marched given requests. 

# What?
Improved MockWebServerRule, so in case of any failure of a test, it will add additional information why given problem occurred. Keep in mind that you won't get any additional test failures in case of you forget to mock something.

So if your app does some `GET /not_mocked` and you check:
```
assertTrue(x)
```

You'll get error test failure, only if "x" is False. But if "x" is False, you'll get additional information in the crash description.

What you need to do is to use: `MockWebServerRule` by adding it to your test:
```kotlin
var mockWebServer: MockWebServerRule = MockWebServerRule()
```

Then write your test:
```kotlin
mockWebServerRule.register {
            expectThat(it).url.path.isEqualTo("/different_url")

            jsonResponse("""{"success": "true"}""")
}

composeTestRule.setContent { YourScreen() }

composeTestRule.onNodeWithText("Data is displayed").assertIsDisplayed()
```

Because instead of mocking `GET /not_mocked`, you mocked GET /different_url`, you'll get the following error

```
com.appunite.loudius.util.MultipleFailuresError: An test exception occurred, but we also found some not mocked requests (2 failures)
	java.lang.AssertionError: Failed to perform isDisplayed check.
    	  Reason: Expected exactly '1' node but could not find any node that satisfies: (Text + EditableText contains 'First Pull-Request title' (ignoreCase: false))
	com.appunite.loudius.util.MultipleFailuresError: Request: GET https://example.com/not_mocked, no mock is matching the request (1 failure)
		strikt.internal.opentest4j.AssertionFailed: ▼ Expect that Request(method=GET, url=https://example.com/not_mocked, headers=Host: localhost:40931,Connection: Keep-Alive,Accept-Encoding: gzip,User-Agent: okhttp/4.10.0):
		  ▼ value of property url:
		    ▼ path:
		      ✗ is equal to "/different_url"
		              found "/not_mocked"
	.....
Caused by: java.lang.AssertionError: Failed to perform isDisplayed check.
	Reason: Expected exactly '1' node but could not find any node that satisfies: (Text + EditableText contains 'First Pull-Request title' (ignoreCase: false))
	
	at androidx.compose.ui.test.SemanticsNodeInteraction.fetchOneOrDie(SemanticsNodeInteraction.kt:145)
	at androidx.compose.ui.test.SemanticsNodeInteraction.fetchSemanticsNode(SemanticsNodeInteraction.kt:79)
	at androidx.compose.ui.test.AndroidAssertions_androidKt.checkIsDisplayed(AndroidAssertions.android.kt:29)
	at androidx.compose.ui.test.AssertionsKt.assertIsDisplayed(Assertions.kt:33)
	... 29 more
```

where you can find the root of failure:
```
Reason: Expected exactly '1' node but could not find any node that satisfies: (Text + EditableText contains 'First Pull-Request title' (ignoreCase: false))
```

where you can find what requests were not mocked:
```
Request: GET https://example.com/not_mocked, no mock is matching the request
```

and you can read why given mocks does not satisfy the provided request:
```
		strikt.internal.opentest4j.AssertionFailed: ▼ Expect that Request(method=GET, url=https://example.com/not_mocked, headers=Host: localhost:40931,Connection: Keep-Alive,Accept-Encoding: gzip,User-Agent: okhttp/4.10.0):
		  ▼ value of property url:
		    ▼ path:
		      ✗ is equal to "/different_url"
		              found "/not_mocked"
```

Now without any debugging, and looking through logs, you see that instead of:
```kotlin
expectThat(it).url.path.isEqualTo("/different_url")
```

you should write:
```kotlin
expectThat(it).url.path.isEqualTo("/not_mocked")
```

Note that you can use this MockWebServerRule with any other assertion library, including AssertJ and harmcrest ;) 
