### PR TITLE
[LD-104] Verify snapshots on ci

### DIFF
--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Prepare Android Environment
         uses: ./.github/actions/prepare-android-env
 
+      - name: LFS-warning
+        uses: ppremk/lfs-warning@v3.2
+
       - name: Gradle - Verify snapshots with Paparazzi
         id: testStep
         run: ./gradlew clean components:verifyPaparazziDebug

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -67,6 +67,11 @@ jobs:
             Snapshot testing result: :heavy_check_mark:
             Everything looks good!
           edit-mode: replace
+          reactions: |
+            heart
+            hooray
+          reactions-edit-mode: replace
+
 
       - name: Create or update comment on PR (Failure)
         uses: peter-evans/create-or-update-comment@v3
@@ -82,3 +87,6 @@ jobs:
             - Unzip and you can find one or more images that show the expected and the actual test results.
             - If these changes are fixing an issue or are part of a new feature then please speak to the maintainer. If they are not intended then please fix them and repush again.
           edit-mode: replace
+          reactions: |
+            confused
+          reactions-edit-mode: replace

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -2,9 +2,9 @@ name: Snapshot verification
 
 on:
   issue_comment:
-    types: [ created, edited ]
+    types: [created, edited]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
 
 permissions:
   checks: write
@@ -34,7 +34,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: snapshot-failure-deltas
-          path: out/failures/
+          path: /Users/runner/work/Loudius/Loudius/components/out/failures/
+
+      - name: Upload snapshot failure report
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: snapshot-failure-report
+          path: /Users/runner/work/Loudius/Loudius/components/build/reports/tests/testDebugUnitTest/
 
       - name: Find PR number
         uses: jwalton/gh-find-current-pr@v1
@@ -49,7 +56,7 @@ jobs:
         if: always()
         with:
           issue-number: ${{ steps.findPr.outputs.pr }}
-          comment-author: 'github-actions[bot]'
+          comment-author: "github-actions[bot]"
           body-includes: Snapshot testing result
 
       - name: Create or update comment on PR (Success)

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -2,7 +2,7 @@ name: Snapshot verification
 
 on:
   issue_comment:
-    types: [created, edited]
+    types: [ created, edited ]
   pull_request:
     branches: [ main, develop, feature/LD-91/golden-tests ]
 
@@ -11,6 +11,7 @@ permissions:
   contents: write
   statuses: write
   pull-requests: write
+  actions: write
 
 jobs:
   test:

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created, edited]
   pull_request:
-    branches: [main, develop]
+    branches: [ main, develop, feature/LD-91/golden-tests ]
 
 permissions:
   checks: write

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -43,17 +43,17 @@ jobs:
 
       - name: Find PR number
         uses: jwalton/gh-find-current-pr@v1
-        id: findPr
+        id: findPRId
         if: always()
         with:
           state: open
 
       - name: Find Comment on PR
         uses: peter-evans/find-comment@v2
-        id: fc
+        id: findCommentId
         if: always()
         with:
-          issue-number: ${{ steps.findPr.outputs.pr }}
+          issue-number: ${{ steps.findPRId.outputs.pr }}
           comment-author: "github-actions[bot]"
           body-includes: Snapshot testing result
 
@@ -61,8 +61,8 @@ jobs:
         uses: peter-evans/create-or-update-comment@v3
         if: always() && steps.testStep.outcome == 'success'
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ steps.findPr.outputs.pr }}
+          comment-id: ${{ steps.findCommentId.outputs.comment-id }}
+          issue-number: ${{ steps.findPRId.outputs.pr }}
           body: |
             Snapshot testing result: :heavy_check_mark:
             Everything looks good!
@@ -77,8 +77,8 @@ jobs:
         uses: peter-evans/create-or-update-comment@v3
         if: always() && steps.testStep.outcome == 'failure'
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ steps.findPr.outputs.pr }}
+          comment-id: ${{ steps.findCommentId.outputs.comment-id }}
+          issue-number: ${{ steps.findPRId.outputs.pr }}
           body: |
             Snapshot testing result: :x:
             Some of the snapshot tests seem to have failed. Please:

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && contains(github.event.comment.html_url, '/pull/') && github.event.comment.body == '!snapshot')
     name: Verify snapshots
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -35,14 +35,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: snapshot-failure-deltas
-          path: /Users/runner/work/Loudius/Loudius/components/out/failures/
+          path: /home/runner/work/Loudius/Loudius/components/out/failures/
 
       - name: Upload snapshot failure report
         if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: snapshot-failure-report
-          path: /Users/runner/work/Loudius/Loudius/components/build/reports/tests/testDebugUnitTest/
+          path: /home/runner/work/Loudius/Loudius/components/build/reports/tests/testDebugUnitTest/
 
       - name: Find PR number
         uses: jwalton/gh-find-current-pr@v1

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -1,8 +1,6 @@
 name: Snapshot verification
 
 on:
-  issue_comment:
-    types: [ created, edited ]
   pull_request:
     branches: [ main, develop, feature/LD-91/golden-tests ]
 
@@ -15,7 +13,6 @@ permissions:
 
 jobs:
   test:
-    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && contains(github.event.comment.html_url, '/pull/') && github.event.comment.body == '!snapshot')
     name: Verify snapshots
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +49,7 @@ jobs:
           state: open
 
       - name: Find Comment on PR
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v2
         id: fc
         if: always()
         with:
@@ -61,7 +58,7 @@ jobs:
           body-includes: Snapshot testing result
 
       - name: Create or update comment on PR (Success)
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v3
         if: always() && steps.testStep.outcome == 'success'
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -72,7 +69,7 @@ jobs:
           edit-mode: replace
 
       - name: Create or update comment on PR (Failure)
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v3
         if: always() && steps.testStep.outcome == 'failure'
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -2,7 +2,6 @@ name: Snapshot verification
 
 on:
   pull_request:
-    branches: [ main, develop, feature/LD-91/golden-tests ]
 
 permissions:
   checks: write

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -1,0 +1,79 @@
+name: Snapshot verification
+
+on:
+  issue_comment:
+    types: [ created, edited ]
+  pull_request:
+    branches: [ main, develop ]
+
+permissions:
+  checks: write
+  contents: write
+  statuses: write
+  pull-requests: write
+
+jobs:
+  test:
+    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && contains(github.event.comment.html_url, '/pull/') && github.event.comment.body == '!snapshot')
+    name: Verify snapshots
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Prepare Android Environment
+        uses: ./.github/actions/prepare-android-env
+
+      - name: Gradle - Verify snapshots with Paparazzi
+        id: testStep
+        run: ./gradlew clean components:verifyPaparazziDebug
+
+      - name: Upload snapshot failure deltas
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: snapshot-failure-deltas
+          path: out/failures/
+
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        if: always()
+        with:
+          state: open
+
+      - name: Find Comment on PR
+        uses: peter-evans/find-comment@v1
+        id: fc
+        if: always()
+        with:
+          issue-number: ${{ steps.findPr.outputs.pr }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Snapshot testing result
+
+      - name: Create or update comment on PR (Success)
+        uses: peter-evans/create-or-update-comment@v1
+        if: always() && steps.testStep.outcome == 'success'
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.findPr.outputs.pr }}
+          body: |
+            Snapshot testing result: :heavy_check_mark:
+            Everything looks good!
+          edit-mode: replace
+
+      - name: Create or update comment on PR (Failure)
+        uses: peter-evans/create-or-update-comment@v1
+        if: always() && steps.testStep.outcome == 'failure'
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.findPr.outputs.pr }}
+          body: |
+            Snapshot testing result: :x:
+            Some of the snapshot tests seem to have failed. Please:
+            - Head over to the artifacts section of the [CI Run](https://github.com/appunite/Loudius/actions/runs/${{ github.run_id }}).
+            - Download the zip.
+            - Unzip and you can find one or more images that show the expected and the actual test results.
+            - If these changes are fixing an issue or are part of a new feature then please speak to the maintainer. If they are not intended then please fix them and repush again.
+          edit-mode: replace

--- a/components/src/main/java/com/appunite/loudius/components/components/LoudiusFullScreenError.kt
+++ b/components/src/main/java/com/appunite/loudius/components/components/LoudiusFullScreenError.kt
@@ -66,10 +66,12 @@ fun ScreenErrorWithSpacers(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(modifier = Modifier.weight(weight = 0.15f))
-        ErrorImage(modifier = Modifier
-            .weight(weight = .35f)
-            .sizeIn(maxWidth = 400.dp, maxHeight = 400.dp)
-            .fillMaxWidth())
+        ErrorImage(
+            modifier = Modifier
+                .weight(weight = .35f)
+                .sizeIn(maxWidth = 400.dp, maxHeight = 400.dp)
+                .fillMaxWidth()
+        )
         Spacer(modifier = Modifier.weight(weight = 0.05f))
         ErrorText(text = errorText)
         LoudiusOutlinedButton(

--- a/components/src/test/java/com/appunite/loudius/components/LoudiusButtonTests.kt
+++ b/components/src/test/java/com/appunite/loudius/components/LoudiusButtonTests.kt
@@ -43,6 +43,7 @@ class LoudiusButtonTests {
     fun loudiusOutlinedButton() {
         paparazzi.snapshot {
             Column(Modifier.background(Color.White)) {
+                LoudiusOutlinedButtonWithIconLargePreview()
                 LoudiusOutlinedButtonDisabledPreview()
                 LoudiusOutlinedButtonWithIconPreview()
                 LoudiusOutlinedButtonLargePreview()

--- a/components/src/test/java/com/appunite/loudius/components/LoudiusButtonTests.kt
+++ b/components/src/test/java/com/appunite/loudius/components/LoudiusButtonTests.kt
@@ -26,7 +26,6 @@ import com.android.ide.common.rendering.api.SessionParams
 import com.appunite.loudius.components.components.LoudiusOutlinedButtonDisabledPreview
 import com.appunite.loudius.components.components.LoudiusOutlinedButtonLargePreview
 import com.appunite.loudius.components.components.LoudiusOutlinedButtonPreview
-import com.appunite.loudius.components.components.LoudiusOutlinedButtonWithIconLargePreview
 import com.appunite.loudius.components.components.LoudiusOutlinedButtonWithIconPreview
 import org.junit.Rule
 import org.junit.Test
@@ -44,7 +43,6 @@ class LoudiusButtonTests {
     fun loudiusOutlinedButton() {
         paparazzi.snapshot {
             Column(Modifier.background(Color.White)) {
-                LoudiusOutlinedButtonWithIconLargePreview()
                 LoudiusOutlinedButtonDisabledPreview()
                 LoudiusOutlinedButtonWithIconPreview()
                 LoudiusOutlinedButtonLargePreview()

--- a/components/src/test/java/com/appunite/loudius/components/LoudiusButtonTests.kt
+++ b/components/src/test/java/com/appunite/loudius/components/LoudiusButtonTests.kt
@@ -26,6 +26,7 @@ import com.android.ide.common.rendering.api.SessionParams
 import com.appunite.loudius.components.components.LoudiusOutlinedButtonDisabledPreview
 import com.appunite.loudius.components.components.LoudiusOutlinedButtonLargePreview
 import com.appunite.loudius.components.components.LoudiusOutlinedButtonPreview
+import com.appunite.loudius.components.components.LoudiusOutlinedButtonWithIconLargePreview
 import com.appunite.loudius.components.components.LoudiusOutlinedButtonWithIconPreview
 import org.junit.Rule
 import org.junit.Test


### PR DESCRIPTION
## Why
To make Golden tests more efficient and simple - check the correctness of snapshots on every PR. 

## Changes
- Prepared Github action for verifying snapshots, which is adding a comment about its result. 

### Behaviour
This workflow provides feedback on pull requests, indicating whether the snapshot tests have passed or failed. Developers can quickly access failure artifacts for further analysis and take appropriate actions to address any issues found during snapshot testing.

On failure: 
Report and deltas screenshots artefacts are uploaded. And the following command is added: 
![Screenshot 2023-05-17 at 15 04 35](https://github.com/appunite/Loudius/assets/33498031/3f242878-f91b-4d70-b8c9-931094c3a31e)
Unfortunately, it's not possible to add images with screenshots to the comment directly, so it's needed to download reports and screenshots from the artifacts. 

On success: 
<img width="921" alt="Screenshot 2023-05-18 at 09 03 27" src="https://github.com/appunite/Loudius/assets/33498031/825cf788-f605-49e9-818e-65cc35028d2c">


[Detailed instruction](https://www.notion.so/appunite/Golden-Tests-with-Paparazzi-Part-2-Verify-on-CI-WIP-1886d84013ae4852829825a9a89ca885)
