### PR TITLE
[LD-82] Cleanup `strings.xml` resources

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_app"
-        android:label="@string/app_name"
+        android:label="@string/common_app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Loudius"
         tools:targetApi="31">

--- a/app/src/main/java/com/appunite/loudius/MainActivity.kt
+++ b/app/src/main/java/com/appunite/loudius/MainActivity.kt
@@ -118,7 +118,7 @@ class MainActivity : ComponentActivity() {
     private fun showAuthFailureToast() {
         Toast.makeText(
             this@MainActivity,
-            getString(R.string.user_unauthorized_message),
+            getString(R.string.common_user_unauthorized_error_message),
             Toast.LENGTH_LONG,
         ).show()
     }

--- a/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/authenticating/AuthenticatingScreen.kt
@@ -68,8 +68,8 @@ private fun ShowLoudiusLoginErrorScreen(
     navigateToLogin: () -> Unit,
 ) {
     LoudiusFullScreenError(
-        errorText = stringResource(id = R.string.error_login_text),
-        buttonText = stringResource(id = R.string.go_to_login),
+        errorText = stringResource(id = R.string.authenticating_screen_error_screen_error_message),
+        buttonText = stringResource(id = R.string.authenticating_screen_error_screen_login_button),
         onButtonClick = navigateToLogin,
     )
 }

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusErrorDialog.kt
@@ -30,8 +30,8 @@ import com.appunite.loudius.ui.theme.LoudiusTheme
 fun LoudiusErrorDialog(
     onConfirmButtonClick: () -> Unit,
     dialogTitle: String = stringResource(id = R.string.error_dialog_title),
-    dialogText: String = stringResource(id = R.string.error_dialog_text),
-    confirmText: String = stringResource(R.string.ok),
+    dialogText: String = stringResource(id = R.string.error_dialog_description),
+    confirmText: String = stringResource(R.string.error_dialog_confirm_button),
 ) {
     var openDialog by remember { mutableStateOf(true) }
     if (openDialog) {

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusFullScreenError.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusFullScreenError.kt
@@ -67,7 +67,7 @@ fun ScreenErrorWithSpacers(
             modifier = Modifier
                 .weight(weight = .35f)
                 .sizeIn(maxWidth = 400.dp, maxHeight = 400.dp)
-                .fillMaxWidth()
+                .fillMaxWidth(),
         )
         Spacer(modifier = Modifier.weight(weight = 0.05f))
         ErrorText(text = errorText)
@@ -114,7 +114,7 @@ fun LoudiusErrorScreenCustomTextsPreview() {
     LoudiusTheme {
         LoudiusFullScreenError(
             errorText = "Custom title",
-            buttonText = "My Button Text"
+            buttonText = "My Button Text",
         ) {}
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusFullScreenError.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusFullScreenError.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.appunite.loudius.R
 import com.appunite.loudius.ui.components.utils.MultiScreenPreviews
@@ -36,8 +37,8 @@ import com.appunite.loudius.ui.theme.LoudiusTheme
 @Composable
 fun LoudiusFullScreenError(
     modifier: Modifier = Modifier,
-    errorText: String = stringResource(id = R.string.error_dialog_text),
-    buttonText: String = stringResource(id = R.string.try_again),
+    errorText: String = stringResource(id = R.string.error_dialog_description),
+    buttonText: String = stringResource(id = R.string.error_dialog_try_again_button),
     onButtonClick: () -> Unit,
 ) {
     ScreenErrorWithSpacers(
@@ -56,11 +57,18 @@ fun ScreenErrorWithSpacers(
     onButtonClick: () -> Unit,
 ) {
     Column(
-        modifier = modifier.padding(32.dp).fillMaxSize(),
+        modifier = modifier
+            .padding(32.dp)
+            .fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(modifier = Modifier.weight(weight = 0.15f))
-        ErrorImage(modifier = Modifier.weight(weight = .35f).sizeIn(maxWidth = 400.dp, maxHeight = 400.dp).fillMaxWidth())
+        ErrorImage(
+            modifier = Modifier
+                .weight(weight = .35f)
+                .sizeIn(maxWidth = 400.dp, maxHeight = 400.dp)
+                .fillMaxWidth()
+        )
         Spacer(modifier = Modifier.weight(weight = 0.05f))
         ErrorText(text = errorText)
         LoudiusOutlinedButton(
@@ -79,7 +87,7 @@ private fun ErrorImage(
     Image(
         modifier = modifier,
         painter = painterResource(id = R.drawable.error_image),
-        contentDescription = stringResource(R.string.error_image_desc),
+        contentDescription = stringResource(R.string.error_dialog_image_content_description),
     )
 }
 
@@ -96,10 +104,17 @@ private fun ErrorText(text: String) {
 @Composable
 fun LoudiusErrorScreenPreview() {
     LoudiusTheme {
+        LoudiusFullScreenError {}
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun LoudiusErrorScreenCustomTextsPreview() {
+    LoudiusTheme {
         LoudiusFullScreenError(
-            errorText = stringResource(id = R.string.error_dialog_text),
-            buttonText = stringResource(R.string.try_again),
-            onButtonClick = {},
-        )
+            errorText = "Custom title",
+            buttonText = "My Button Text"
+        ) {}
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusPlaceholderText.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusPlaceholderText.kt
@@ -16,21 +16,18 @@
 
 package com.appunite.loudius.ui.components
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.appunite.loudius.R
 import com.appunite.loudius.ui.theme.LoudiusTheme
 
 @Composable
-fun LoudiusPlaceholderText(@StringRes textId: Int) {
+fun LoudiusPlaceholderText(text: String) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -38,7 +35,7 @@ fun LoudiusPlaceholderText(@StringRes textId: Int) {
         contentAlignment = Alignment.Center,
     ) {
         LoudiusText(
-            text = stringResource(id = textId),
+            text = text,
             style = LoudiusTextStyle.ScreenContent,
         )
     }
@@ -48,6 +45,6 @@ fun LoudiusPlaceholderText(@StringRes textId: Int) {
 @Composable
 fun PreviewLoudiusPlaceholderText() {
     LoudiusTheme {
-        LoudiusPlaceholderText(R.string.you_dont_have_any_pull_request)
+        LoudiusPlaceholderText("Sorry! Your list of pull requests is empty.\\nGet back to work! \uD83E\uDDD1\u200D")
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/components/LoudiusTopAppBar.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/components/LoudiusTopAppBar.kt
@@ -47,7 +47,7 @@ fun LoudiusTopAppBar(
                 IconButton(onClick = onClickBackArrow) {
                     Icon(
                         painter = painterResource(id = R.drawable.arrow_back),
-                        contentDescription = stringResource(R.string.back_button),
+                        contentDescription = stringResource(R.string.common_back_button_icon_content_description),
                     )
                 }
             }

--- a/app/src/main/java/com/appunite/loudius/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/login/LoginScreen.kt
@@ -84,12 +84,12 @@ fun LoginScreenStateless(
             onClick = {
                 onAction(LoginAction.ClickLogIn)
             },
-            text = stringResource(id = R.string.login_screen_login),
+            text = stringResource(id = R.string.login_screen_login_button),
             style = LoudiusOutlinedButtonStyle.Large,
             icon = {
                 LoudiusOutlinedButtonIcon(
                     painter = painterResource(id = R.drawable.ic_github),
-                    contentDescription = stringResource(R.string.github_icon),
+                    contentDescription = stringResource(R.string.login_screen_github_icon_content_description),
                 )
             },
         )

--- a/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/pullrequests/PullRequestsScreen.kt
@@ -89,7 +89,7 @@ private fun PullRequestsScreenStateless(
 ) {
     Scaffold(
         topBar = {
-            LoudiusTopAppBar(title = stringResource(R.string.app_name))
+            LoudiusTopAppBar(title = stringResource(R.string.common_app_name))
         },
         content = { padding ->
             when (state.data) {
@@ -188,7 +188,7 @@ private fun RepoDetails(modifier: Modifier, pullRequestTitle: String, repository
 private fun EmptyListPlaceholder(padding: PaddingValues) {
     Box(modifier = Modifier.padding(padding)) {
         LoudiusPlaceholderText(
-            textId = R.string.you_dont_have_any_pull_request,
+            text = stringResource(id = R.string.ull_requests_screen_you_dont_have_any_pull_request_message),
         )
     }
 }

--- a/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
+++ b/app/src/main/java/com/appunite/loudius/ui/reviewers/ReviewersScreen.kt
@@ -98,8 +98,8 @@ private fun SnackbarLaunchedEffect(
 @Composable
 private fun resolveSnackbarMessage(snackbarTypeShown: ReviewersSnackbarType) =
     when (snackbarTypeShown) {
-        SUCCESS -> stringResource(id = R.string.reviewers_snackbar_success)
-        FAILURE -> stringResource(id = R.string.reviewers_snackbar_failure)
+        SUCCESS -> stringResource(id = R.string.reviewers_screen_snackbar_success_message)
+        FAILURE -> stringResource(id = R.string.reviewers_screen_snackbar_failure_message)
     }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -115,7 +115,7 @@ private fun ReviewersScreenStateless(
         topBar = {
             LoudiusTopAppBar(
                 onClickBackArrow = onClickBackArrow,
-                title = stringResource(id = R.string.details_title, pullRequestNumber),
+                title = stringResource(id = R.string.reviewers_screen_title, pullRequestNumber),
             )
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -197,7 +197,7 @@ private fun NotifyButtonOrLoadingIndicator(
 ) {
     Box(contentAlignment = Center) {
         LoudiusOutlinedButton(
-            text = stringResource(R.string.details_notify),
+            text = stringResource(R.string.reviewers_screen_notify_button),
             onClick = { onNotifyClick(ReviewersAction.Notify(reviewer.login)) },
             modifier = Modifier.alpha(if (reviewer.isLoading) 0f else 1f),
         )
@@ -212,7 +212,7 @@ private fun ReviewerAvatarView(modifier: Modifier = Modifier) {
     LoudiusListIcon(
         painter = painterResource(id = R.drawable.person_outline_24px),
         contentDescription = stringResource(
-            R.string.details_screen_user_image_description,
+            R.string.reviewers_screen_user_image_content_description,
         ),
         modifier = modifier,
     )
@@ -228,9 +228,9 @@ private fun IsReviewedHeadlineText(reviewer: Reviewer) {
 
 @Composable
 private fun resolveIsReviewedText(reviewer: Reviewer) = if (reviewer.isReviewDone) {
-    stringResource(id = R.string.details_reviewed, reviewer.hoursFromReviewDone ?: 0)
+    stringResource(id = R.string.reviewers_screen_reviewed_message, reviewer.hoursFromReviewDone ?: 0)
 } else {
-    stringResource(id = R.string.details_not_reviewed, reviewer.hoursFromPRStart)
+    stringResource(id = R.string.reviewers_screen_not_reviewed_message, reviewer.hoursFromPRStart)
 }
 
 @Composable
@@ -245,7 +245,7 @@ private fun ReviewerName(reviewer: Reviewer) {
 private fun EmptyListPlaceholder(padding: PaddingValues) {
     Box(modifier = Modifier.padding(padding)) {
         LoudiusPlaceholderText(
-            textId = R.string.you_dont_have_any_reviewers,
+            text = stringResource(R.string.reviewers_screen_you_dont_have_any_reviewers_message),
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,32 +1,44 @@
 <resources>
-    <string name="app_name">Loudius</string>
-    <string name="back_button">Back button</string>
-    <string name="pull_requests_screen_pull_request_content_description">Pull request</string>
-    <string name="details_screen_user_image_description">User image</string>
-    <string name="details_notify">Notify</string>
-    <string name="details_reviewed">Reviewed %d h ago.</string>
-    <string name="details_not_reviewed">Not reviewed for %d h.</string>
-    <string name="details_title">Pull request # %s</string>
-    <string name="github_icon">Github icon</string>
+    <!-- Common string resources -->
+    <string name="common_app_name">Loudius</string>
+    <string name="common_back_button_icon_content_description">Back button</string>
+    <string name="common_user_unauthorized_error_message">Unauthorized collaborator detected! Please login again.</string>
+
+    <!-- LoudiusErrorDialog -->
     <string name="error_dialog_title">Error</string>
-    <string name="error_dialog_text">Something went wrong…</string>
-    <string name="ok">OK</string>
-    <string name="error_image_desc">error image</string>
-    <string name="try_again">Try again</string>
-    <string name="error_login_text">Something went wrong…\nYou need to log in again.</string>
-    <string name="go_to_login">Take me to login</string>
-    <string name="reviewers_snackbar_success">Awesome! Your collaborator have been pinged for some serious code review action! 🎉</string>
-    <string name="reviewers_snackbar_failure">Uh-oh, it seems that Loudius has taken a vacation. Don\'t worry, we\'re sending a postcard to bring it back ASAP!</string>
-    <string name="user_unauthorized_message">Unauthorized collaborator detected! Please login again.</string>
-    <string name="you_dont_have_any_pull_request">Sorry! Your list of pull requests is empty.\nGet back to work! 🧑‍💻</string>
-    <string name="you_dont_have_any_reviewers">Sorry! Your list of reviewers is empty.\n Go to pull request and mark your colleagues as the reviewers! 🤞</string>
+    <string name="error_dialog_description">Something went wrong…</string>
+    <string name="error_dialog_confirm_button">OK</string>
+    <string name="error_dialog_image_content_description">error image</string>
+    <string name="error_dialog_try_again_button">Try again</string>
+
+    <!-- AuthenticatingScreen -->
+    <!-- AuthenticatingScreen -> error screen -->
+    <string name="authenticating_screen_error_screen_error_message">Something went wrong…\nYou need to log in again.</string>
+    <string name="authenticating_screen_error_screen_login_button">Take me to login</string>
 
     <!-- LoginScreen -->
-    <string name="login_screen_login">Log in</string>
+    <string name="login_screen_login_button">Log in</string>
+    <string name="login_screen_github_icon_content_description">Github icon</string>
     <string name="login_screen_loudius_logo_content_description">Loudius logo</string>
+
+    <!-- LoginScreen -> XiaomiPermissionDialog -->
     <string name="login_screen_xiaomi_dialog_grant_permission">Grant permission</string>
     <string name="login_screen_xiaomi_dialog_text">You\'re using a Xiaomi device and you have Github App installed, please note that there\'s a known bug that requires you to grant the \"Display pup-up windows while running in the background\" permission. This will allow you to continue using the app without any interruptions.</string>
     <string name="login_screen_xiaomi_dialog_title">Necessary permissions</string>
     <string name="login_screen_xiaomi_dialog_already_granted">I\'ve already granted</string>
+
+    <!-- PullRequestsScreen -->
+    <string name="ull_requests_screen_you_dont_have_any_pull_request_message">Sorry! Your list of pull requests is empty.\nGet back to work! 🧑‍💻</string>
+    <string name="pull_requests_screen_pull_request_content_description">Pull request</string>
+
+    <!-- ReviewersScreen -->
+    <string name="reviewers_screen_snackbar_success_message">Awesome! Your collaborator have been pinged for some serious code review action! 🎉</string>
+    <string name="reviewers_screen_snackbar_failure_message">Uh-oh, it seems that Loudius has taken a vacation. Don\'t worry, we\'re sending a postcard to bring it back ASAP!</string>
+    <string name="reviewers_screen_user_image_content_description">User image</string>
+    <string name="reviewers_screen_notify_button">Notify</string>
+    <string name="reviewers_screen_reviewed_message">Reviewed %d h ago.</string>
+    <string name="reviewers_screen_not_reviewed_message">Not reviewed for %d h.</string>
+    <string name="reviewers_screen_title">Pull request # %s</string>
+    <string name="reviewers_screen_you_dont_have_any_reviewers_message">Sorry! Your list of reviewers is empty.\n Go to pull request and mark your colleagues as the reviewers! 🤞</string>
 
 </resources>


### PR DESCRIPTION
# Hypothesis
By adding prefixes to strings resources, translations can be done easier and better.

# Description
When we have a string resource described as just `<string name="ok">OK</string>` the resource is shared across many places. This might feel right, but when translating such resource, you don't give any clue to translator what it does. Actually, when translating, certain situations might need to have different translations. I.e. in case of a button that user need to hit after saving data, we might translate "OK" to "W porządku" (pl_PL), but in case of error message, this doesn't work well, in this case we should translate it to "Potwierdzam" (pl_PL). This is why we should allow translating case by case. 

As I mentioned before, knowing the context where a translation is placed in which context is essential to a translator to provide good translation. Adding information about which screen is given translation related too is very useful. So instead of 
`<string name="error_message">Something went wrong…\nYou need to log in again.</string>` we should name this resource `<string name="authenticating_screen_error_screen_error_message">Something went wrong…\nYou need to log in again.</string>`

Let's give another example. We have a log-in screen, and we have resource declared as: `<string name="login_screen_login">Log in</string>`. When translating this resource to polish, the translator might consider translating it to "Zaloguj się" or "Ekran logowania" depending on if this is a title or a CTA. This is why we should add such information to the string resource. So instead of `<string name="login_screen_login">Log in</string>`, we should use `<string name="login_screen_login_button">Log in</string>` and `<string name="login_screen_login_title">Log in</string>`

Of course, there are some common texts that are always the same and always used in the same context. Let's highlight some examples:
* App name
* Content description of back button that is on all screens
* Message of a generic snack bar
* Retry button on the error snack bar
You should keep reusing, but it's better to prefix them, so you always know what this given resource is re-used between different components.
So instead of `<string name="app_name">Loudius</string>` type `<string name="common_app_name">Loudius</string>`

## Summary

<details>
  <summary>So from something that is untranslatable</summary>

```xml
<resources>
    <string name="app_name">Loudius</string>
    <string name="back_button">Back button</string>
    <string name="pull_requests_screen_pull_request_content_description">Pull request</string>
    <string name="details_screen_user_image_description">User image</string>
    <string name="details_notify">Notify</string>
    <string name="details_reviewed">Reviewed %d h ago.</string>
    <string name="details_not_reviewed">Not reviewed for %d h.</string>
    <string name="details_title">Pull request # %s</string>
    <string name="github_icon">Github icon</string>
    <string name="error_dialog_title">Error</string>
    <string name="error_dialog_text">Something went wrong…</string>
    <string name="ok">OK</string>
    <string name="error_image_desc">error image</string>
    <string name="try_again">Try again</string>
    <string name="error_login_text">Something went wrong…\nYou need to log in again.</string>
    <string name="go_to_login">Take me to login</string>
    <string name="reviewers_snackbar_success">Awesome! Your collaborator have been pinged for some serious code review action! 🎉</string>
    <string name="reviewers_snackbar_failure">Uh-oh, it seems that Loudius has taken a vacation. Don\'t worry, we\'re sending a postcard to bring it back ASAP!</string>
    <string name="user_unauthorized_message">Unauthorized collaborator detected! Please login again.</string>
    <string name="you_dont_have_any_pull_request">Sorry! Your list of pull requests is empty.\nGet back to work! 🧑‍💻</string>
    <string name="you_dont_have_any_reviewers">Sorry! Your list of reviewers is empty.\n Go to pull request and mark your colleagues as the reviewers! 🤞</string>

    <!-- LoginScreen -->
    <string name="login_screen_login">Log in</string>
    <string name="login_screen_loudius_logo_content_description">Loudius logo</string>
    <string name="login_screen_xiaomi_dialog_grant_permission">Grant permission</string>
    <string name="login_screen_xiaomi_dialog_text">You\'re using a Xiaomi device and you have Github App installed, please note that there\'s a known bug that requires you to grant the \"Display pup-up windows while running in the background\" permission. This will allow you to continue using the app without any interruptions.</string>
    <string name="login_screen_xiaomi_dialog_title">Necessary permissions</string>
    <string name="login_screen_xiaomi_dialog_already_granted">I\'ve already granted</string>

</resources>
```

</details>


<details>
  <summary>We get something that can be translated</summary>

```xml
<resources>
    <!-- Common string resources -->
    <string name="common_app_name">Loudius</string>
    <string name="common_back_button_icon_content_description">Back button</string>
    <string name="common_user_unauthorized_error_message">Unauthorized collaborator detected! Please login again.</string>

    <!-- LoudiusErrorDialog -->
    <string name="error_dialog_title">Error</string>
    <string name="error_dialog_description">Something went wrong…</string>
    <string name="error_dialog_confirm_button">OK</string>
    <string name="error_dialog_image_content_description">error image</string>
    <string name="error_dialog_try_again_button">Try again</string>

    <!-- AuthenticatingScreen -->
    <!-- AuthenticatingScreen -> error screen -->
    <string name="authenticating_screen_error_screen_error_message">Something went wrong…\nYou need to log in again.</string>
    <string name="authenticating_screen_error_screen_login_button">Take me to login</string>

    <!-- LoginScreen -->
    <string name="login_screen_login_button">Log in</string>
    <string name="login_screen_github_icon_content_description">Github icon</string>
    <string name="login_screen_loudius_logo_content_description">Loudius logo</string>

    <!-- LoginScreen -> XiaomiPermissionDialog -->
    <string name="login_screen_xiaomi_dialog_grant_permission">Grant permission</string>
    <string name="login_screen_xiaomi_dialog_text">You\'re using a Xiaomi device and you have Github App installed, please note that there\'s a known bug that requires you to grant the \"Display pup-up windows while running in the background\" permission. This will allow you to continue using the app without any interruptions.</string>
    <string name="login_screen_xiaomi_dialog_title">Necessary permissions</string>
    <string name="login_screen_xiaomi_dialog_already_granted">I\'ve already granted</string>

    <!-- PullRequestsScreen -->
    <string name="ull_requests_screen_you_dont_have_any_pull_request_message">Sorry! Your list of pull requests is empty.\nGet back to work! 🧑‍💻</string>
    <string name="pull_requests_screen_pull_request_content_description">Pull request</string>

    <!-- ReviewersScreen -->
    <string name="reviewers_screen_snackbar_success_message">Awesome! Your collaborator have been pinged for some serious code review action! 🎉</string>
    <string name="reviewers_screen_snackbar_failure_message">Uh-oh, it seems that Loudius has taken a vacation. Don\'t worry, we\'re sending a postcard to bring it back ASAP!</string>
    <string name="reviewers_screen_user_image_content_description">User image</string>
    <string name="reviewers_screen_notify_button">Notify</string>
    <string name="reviewers_screen_reviewed_message">Reviewed %d h ago.</string>
    <string name="reviewers_screen_not_reviewed_message">Not reviewed for %d h.</string>
    <string name="reviewers_screen_title">Pull request # %s</string>
    <string name="reviewers_screen_you_dont_have_any_reviewers_message">Sorry! Your list of reviewers is empty.\n Go to pull request and mark your colleagues as the reviewers! 🤞</string>

</resources>
```

</details>
