### PR TITLE
[LD-98] Add github action for recording snapshots. [New snapshots]

### DIFF
--- a/.github/workflows/run-snapshot-generation.yml
+++ b/.github/workflows/run-snapshot-generation.yml
@@ -1,3 +1,4 @@
+---
 name: Snapshot recording
 
 on:
@@ -39,8 +40,64 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: snapshot-failure-deltas
-          path: /home/runner/work/Loudius/Loudius/components/build/reports/paparazzi/
+          name: snapshot-recording-failure-report
+          path: /home/runner/work/Loudius/Loudius/components/build/reports/tests/testDebugUnitTest/
 
       - name: LFS-warning
         uses: ppremk/lfs-warning@v3.2
+
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPRId
+        if: always()
+        with:
+          state: open
+
+      - name: Find Comment on PR
+        uses: peter-evans/find-comment@v2
+        id: findCommentId
+        if: always()
+        with:
+          issue-number: ${{ steps.findPRId.outputs.pr }}
+          comment-author: "github-actions[bot]"
+          body-regex: 'Snapshot (testing|recording) result:'
+
+      - name: Create or update comment on PR (Success)
+        uses: peter-evans/create-or-update-comment@v3
+        if: always() && steps.testStep.outcome == 'success'
+        with:
+          comment-id: ${{ steps.findCommentId.outputs.comment-id }}
+          issue-number: ${{ steps.findPRId.outputs.pr }}
+          body: |
+            Snapshot recording result: :heavy_check_mark:
+            New snapshots recorded! Everything looks good!
+
+            If there were changes in the user interface, a new commit has been created. You can review the new snapshots in the diff. If you find them acceptable, please proceed to merge this pull request.
+
+            However, if you did not intend to record new snapshots, please remove the '[New snapshots]' part from your title (and discard the commit that includes the new snapshots). It will cause to run snapshot verification instead of recording.
+          edit-mode: replace
+          reactions: |
+            heart
+            hooray
+          reactions-edit-mode: replace
+
+
+      - name: Create or update comment on PR (Failure)
+        uses: peter-evans/create-or-update-comment@v3
+        if: always() && steps.testStep.outcome == 'failure'
+        with:
+          comment-id: ${{ steps.findCommentId.outputs.comment-id }}
+          issue-number: ${{ steps.findPRId.outputs.pr }}
+          body: |
+            Snapshot recording result: :x:
+            Something went wrong during snapshot recording. 
+            If you need further investigation: 
+            - Head over to the artifacts section of the [CI Run](https://github.com/appunite/Loudius/actions/runs/${{ github.run_id }}).
+            - Download the zip.
+            - Unzip and you can find report showing the problem
+            
+            If you not intended to record new snapshots please remove '[New snapshots]' part from your pull request title. It will cause to run snapshot verification instead of recording.
+          edit-mode: replace
+          reactions: |
+            confused
+          reactions-edit-mode: replace

--- a/.github/workflows/run-snapshot-generation.yml
+++ b/.github/workflows/run-snapshot-generation.yml
@@ -90,8 +90,8 @@ jobs:
           issue-number: ${{ steps.findPRId.outputs.pr }}
           body: |
             Snapshot recording result: :x:
-            Something went wrong during snapshot recording. 
-            If you need further investigation: 
+            Something went wrong during snapshot recording.
+            If you need further investigation:
             - Head over to the artifacts section of the [CI Run](https://github.com/appunite/Loudius/actions/runs/${{ github.run_id }}).
             - Download the zip.
             - Unzip and you can find report showing the problem

--- a/.github/workflows/run-snapshot-generation.yml
+++ b/.github/workflows/run-snapshot-generation.yml
@@ -22,10 +22,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Set up Git LFS
-        run: |
-          git lfs install
-
       - name: Gradle - Record snapshots with Paparazzi
         id: testStep
         run: ./gradlew clean components:recordPaparazziDebug
@@ -42,9 +38,6 @@ jobs:
         with:
           name: snapshot-recording-failure-report
           path: /home/runner/work/Loudius/Loudius/components/build/reports/tests/testDebugUnitTest/
-
-      - name: LFS-warning
-        uses: ppremk/lfs-warning@v3.2
 
       - name: Find PR number
         uses: jwalton/gh-find-current-pr@v1

--- a/.github/workflows/run-snapshot-generation.yml
+++ b/.github/workflows/run-snapshot-generation.yml
@@ -1,4 +1,7 @@
 ---
+# Golden tests recording with Paparazzi configuration file
+# Add [New snapshots] to the title of your PR to record new snapshots.
+# Remove it to verify snapshots instead.
 name: Snapshot recording
 
 on:

--- a/.github/workflows/run-snapshot-generation.yml
+++ b/.github/workflows/run-snapshot-generation.yml
@@ -1,0 +1,46 @@
+name: Snapshot recording
+
+on:
+  pull_request:
+    types: [ opened, edited , synchronize ]
+
+permissions:
+  checks: write
+  contents: write
+  statuses: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  generate_snapshots:
+    if: ${{contains(github.event.pull_request.title, '[New snapshots]')}}
+    name: Generate snapshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Set up Git LFS
+        run: |
+          git lfs install
+
+      - name: Gradle - Record snapshots with Paparazzi
+        id: testStep
+        run: ./gradlew clean components:recordPaparazziDebug
+
+      - name: Commit and push recorded screenshots
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
+          commit_message: "[Paparazzi] Record new snapshots"
+
+      - name: Upload snapshot record report
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: snapshot-failure-deltas
+          path: /home/runner/work/Loudius/Loudius/components/build/reports/paparazzi/
+
+      - name: LFS-warning
+        uses: ppremk/lfs-warning@v3.2

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   test:
+    if: ${{!contains(github.event.pull_request.title, '[New snapshots]')}}
     name: Verify snapshots
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -1,3 +1,4 @@
+---
 name: Snapshot verification
 
 on:
@@ -58,7 +59,7 @@ jobs:
         with:
           issue-number: ${{ steps.findPRId.outputs.pr }}
           comment-author: "github-actions[bot]"
-          body-includes: Snapshot testing result
+          body-regex: 'Snapshot (testing|recording) result:'
 
       - name: Create or update comment on PR (Success)
         uses: peter-evans/create-or-update-comment@v3

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,7 +1,17 @@
 {
   "threshold": 0,
-  "reporters": ["html", "console", "xml"],
-  "ignore": ["**/__snapshots__/**", "**/src/test/java/**"],
-  "ignorePattern": ["import .*"],
+  "reporters": [
+    "html",
+    "console",
+    "xml"
+  ],
+  "ignore": [
+    "**/__snapshots__/**",
+    "**/src/test/java/**",
+    "**/workflows/**"
+  ],
+  "ignorePattern": [
+    "import .*"
+  ],
   "absolute": true
 }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Here's an example of an experiment that meets our rules:
 
 ## 🚀 Project setup
 
-In order to properly start the application and use it, the CLIENT_SECRET environment variable must be set on your computer. CLIENT_SECRET is a GitHub client secret key provided from ``Settings -> Developer Settings -> OAuth Apps -> my application``.
+In order to properly start the application and use it, the CLIENT_SECRET environment variable must
+be set on your computer. CLIENT_SECRET is a GitHub client secret key provided
+from ``Settings -> Developer Settings -> OAuth Apps -> my application``.
 
 ### How to set environmental variable on mac?
 
@@ -74,6 +76,11 @@ In order to properly start the application and use it, the CLIENT_SECRET environ
 2. `$ echo 'export CLIENT_SECRET=you know what' >> ~/.zshenv`
 3. `$ echo $CLIENT_SECRET`
 4. Restart your computer.
+
+### Screenshots tests
+
+We are using screenshot tests to check if the UI is not broken. We are recording screenshots on CI.
+To do that - add `[New snapshots]` to the pull request title. Otherwise the snapshots are tested.
 
 ## 🧑🏻‍🎓 Contributing
 

--- a/components/src/test/snapshots/images/com.appunite.loudius.components_LoudiusDialogTest_loudiusFullScreenErrorTest.png
+++ b/components/src/test/snapshots/images/com.appunite.loudius.components_LoudiusDialogTest_loudiusFullScreenErrorTest.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fc6324ad4c8908a9c7697621ef4a95783558b37a2b5932b5a4cadc8c377cd6b
-size 55745
+oid sha256:2cf086878480f21ad538d389920718c38fc320479c4a0a7cc8cc4e92c492e7dc
+size 55744


### PR DESCRIPTION
## Why? 
Generating snapshots on different OS sometimes results in a few different pixels. Generating ones on CI resolves that issue. 

## Changes
- added generating screenshots on CI by adding [New snapshots] to the pull request title. Otherwise, snapshots are verified on every pull request. 
- one new screenshot recorded (different rendering on Ubuntu then on mac-os for this particular snapshot)
- excluded `workflow` directory from jscpd linter checks (copy-paste checks) 

## Behaviour
Adding [New snapshots] to the pull request title results in recording new snapshots and auto-committing new ones to the repo. **Adds only the one that has changed with the commit**.
Pull requests without [New snapshots] in a title will run the `verify snapshots` job. 
Recording and verifying tasks show its result in a single comment. 


