### PR TITLE
[LD-108] Remove orphan github workflows

### DIFF
--- a/.github/workflows/run-code-quality-check.yml
+++ b/.github/workflows/run-code-quality-check.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     name: MegaLinter
     runs-on: ubuntu-latest
+    if: false # Set to true to enable this job
     steps:
       # Git Checkout
       - name: Checkout Code

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -13,7 +13,8 @@ permissions:
 
 jobs:
   test:
-    if: ${{!contains(github.event.pull_request.title, '[New snapshots]')}}
+    if: false # Set to true to enable this job
+    #if: ${{!contains(github.event.pull_request.title, '[New snapshots]')}}
     name: Verify snapshots
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -124,8 +124,11 @@ jobs:
           "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices")
 
           echo "Test Matrix response body: $responseBody"
+          test_matrix_id=$(echo "$response" | jq -r '.testMatrixId')
+          
+          echo "Test Matrix ID: $test_matrix_id"
+          echo $test_matrix_id > test_matrix_id.txt
           echo "::set-output name=testMatrixId::$matrixId"
-
 
       - name: Upload test matrix ID artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -129,17 +129,17 @@ jobs:
             "testSpecification": {
               "androidInstrumentationTest": {
                 "testApk": {
-                  "gcsPath": gs://${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
+                  "gcsPath": gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
                 },
                 "appPackageId": "com.appunite.loudius",
                 "appApk": {
-                  "gcsPath": gs://${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
+                  "gcsPath": gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
                 }
               }
             },
             "resultStorage": {
               "googleCloudStorage": {
-                "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
+                "gcsPath": "gs:/${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
               }
             }
           }'

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -157,3 +157,14 @@ jobs:
           else
             python "build-tools/upload-junit-to-cloud.py"
           fi
+
+      - name: Check for the test status x2
+        run: |
+          sleep 100
+          
+          responseBody=$(curl -X GET \
+          -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+          -H "Content-Type: application/json" \
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices/${{steps.tests.outputs.testMatrixId}}"/)
+          
+          echo "Test Matrix response body from get: $responseBody"

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -102,8 +102,6 @@ jobs:
         run: |-
           echo "results_dir=$(date +%F_%T)-${RANDOM}" >> "$GITHUB_OUTPUT"
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
-          
-          gsutil mb gs://app-debug.apk
 
       - name: Create directories on GCS
         run: |

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -142,9 +142,9 @@ jobs:
           responseBody=$(curl -X GET \
           -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
           -H "Content-Type: application/json" \
-          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices/steps.tests.testMatrixId"/)
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices/${{steps.tests.testMatrixId}}"/)
           
-            echo "Test Matrix response body from get: $responseBody"
+          echo "Test Matrix response body from get: $responseBody"
 
 
       - name: Upload to Big Query

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -48,10 +48,21 @@ jobs:
         with:
           python-version: 3.x
 
+      - name: Download test matrix ID artifact
+        if: github.ref == 'refs/heads/your-branch-name'
+        uses: actions/download-artifact@v2
+        with:
+          name: test-matrix-id
+
+      - name: Set testMatrixId output
+        id: previous_test_matrix
+        if: github.ref == ${{ github.ref}} && steps.download.outputs.artifacts_downloaded == 'true'
+        run: echo "::set-output name=testMatrixId::$(cat test_matrix_id.txt)"
+
       - name: Cancel previous test run on Firebase Test Lab
         if: steps.run_tests.outputs.testMatrixId != ''
         run: |
-          gcloud firebase test android matrices cancel ${{ steps.run_tests.outputs.testMatrixId }}
+          gcloud firebase test android matrices cancel ${{ steps.previous_test_matrix.outputs.testMatrixId }}
 
       - name: Prepare Android Environment
         uses: ./.github/actions/prepare-android-env
@@ -74,8 +85,14 @@ jobs:
         id: run_tests
         run: |-
           output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}")
-          testMatrixId=$(echo "$output" | grep -oP "Test \[matrix-\K[^]]+")
+          testMatrixId=$(echo "$output" | grep -oP "matrix-(\w+)")
           echo "::set-output name=testMatrixId::$testMatrixId"
+
+      - name: Upload test matrix ID artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-matrix-id
+          path: test_matrix_id.txt
 
       - name: Upload to Big Query
         if: always()

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -116,7 +116,6 @@ jobs:
           echo "Firebase project id: ${{secrets.FIREBASE_PROJECT_ID}}" 
 
           matrixId=$(curl -X POST \
-          -H "Authorization: Bearer ${{ secrets.SERVICE_ACCOUNT }}" \
           -H "Content-Type: application/json" \
           -d "$requestBody" \
           "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices" | jq -r '.testMatrixId')

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -85,7 +85,8 @@ jobs:
         id: run_tests
         run: |-
           output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}")
-          echo "Running tests on Firebase Test Lab... -Output: $output. Now I am trying to extract testMatrixId. "
+          echo "Running tests on Firebase Test Lab... -Output: $output.
+          Now I am trying to extract testMatrixId. "
           testMatrixId=$(echo "$output" | grep -oP "matrix-(\w+)")
           echo "::set-output name=testMatrixId::$testMatrixId"
 

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -124,7 +124,7 @@ jobs:
           "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices")
 
           echo "Test Matrix response body: $responseBody"
-          test_matrix_id=$(echo "$response" | jq -r '.testMatrixId')
+          test_matrix_id=$(echo "responseBody" | jq -r '.testMatrixId')
           
           echo "Test Matrix ID: $test_matrix_id"
           echo $test_matrix_id > test_matrix_id.txt

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -91,22 +91,24 @@ jobs:
             exit 1
           fi
 
-      - name: Upload APK to GCS
-        run: |
-          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
-          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
-
-
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:
           install_components: "gsutil"
+
 
       - id: generate-dir
         name: Generate random directory
         run: |-
           echo "results_dir=$(date +%F_%T)-${RANDOM}" >> "$GITHUB_OUTPUT"
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
+
+
+      - name: Upload APK to GCS
+        run: |
+          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
+          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
+
 
 
       - name: Create Firebase Test Lab Matrix

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -86,6 +86,7 @@ jobs:
 
 
       - name: Create Firebase Test Lab Matrix
+        id: tests
         run: |
           requestBody='{
             "environmentMatrix": {
@@ -135,6 +136,16 @@ jobs:
         with:
           name: test-matrix-id
           path: test_matrix_id.txt
+
+      - name: Check for the test status
+        run: |
+          responseBody=$(curl -X GET \
+          -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+          -H "Content-Type: application/json" \
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices/steps.tests.testMatrixId"/)
+          
+            echo "Test Matrix response body from get: $responseBody"
+
 
       - name: Upload to Big Query
         if: always()

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -103,14 +103,10 @@ jobs:
           echo "results_dir=$(date +%F_%T)-${RANDOM}" >> "$GITHUB_OUTPUT"
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
 
-      - name: Create directory on GCS
-        run: |
-          gsutil mb gs://${{ steps.generate-dir.outputs.bucket }}
-
       - name: Upload APK to GCS
         run: |
-          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug
-          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest
+          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs:/${{ steps.generate-dir.outputs.bucket }}
+          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs:/${{ steps.generate-dir.outputs.bucket }}
 
 
 

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -129,7 +129,7 @@ jobs:
           
           echo "Test Matrix ID: $test_matrix_id"
           echo $test_matrix_id > test_matrix_id.txt
-          echo "::set-output name=testMatrixId::$matrixId"
+          echo "::set-output name=testMatrixId::$test_matrix_id"
 
       - name: Upload test matrix ID artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -87,9 +87,6 @@ jobs:
 
       - name: Create Firebase Test Lab Matrix
         run: |
-          projectId=${{ secrets.FIREBASE_PROJECT_ID }}
-          accessToken=${{ secrets.SERVICE_ACCOUNT }}
-
           requestBody='{
           "environmentMatrix": {
           "androidDeviceList": {
@@ -115,10 +112,10 @@ jobs:
           }'
 
           matrixId=$(curl -X POST \
-          -H "Authorization: Bearer $accessToken" \
+          -H "Authorization: Bearer ${{ secrets.SERVICE_ACCOUNT }}" \
           -H "Content-Type: application/json" \
           -d "$requestBody" \
-          "https://testing.googleapis.com/v1/projects/$projectId/testMatrices" | jq -r '.testMatrixId')
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices" | jq -r '.testMatrixId')
 
           echo "Test Matrix ID: $matrixId"
           echo "::set-output name=testMatrixId::$matrixId"

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -89,6 +89,7 @@ jobs:
           Now I am trying to extract testMatrixId. "
           testMatrixId=$(echo "$output" | grep -oP "matrix-(\w+)")
           echo "::set-output name=testMatrixId::$testMatrixId"
+          echo "::set-output name=testMatrixId::$testMatrixId" >> test_matrix_id.txt
 
       - name: Upload test matrix ID artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -110,7 +110,7 @@ jobs:
                 }
               }
             },
-            "resultsStorage": {
+            "resultStorage": {
               "googleCloudStorage": {
                 "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
               }

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -12,6 +12,10 @@ on:
     # guess CI is less occupied. And 13 is a lucky number ;)
     - cron: "13 9,21 * * *"
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -25,8 +25,6 @@ jobs:
 
     steps:
       - name: Checkout
-        with:
-          token: ${{secrets.FIREBASE_PROJECT_ID }}
         uses: actions/checkout@v3
 
       - name: Set up Python

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -115,7 +115,7 @@ jobs:
           -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
           -H "Content-Type: application/json" \
           -d "$requestBody" \
-          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices" | jq -r '.testMatrixId')
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices")
 
           echo "Test Matrix ID: $matrixId"
           echo "::set-output name=testMatrixId::$matrixId"

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -118,7 +118,7 @@ jobs:
           matrixId=`(curl -X POST \
           -H "Content-Type: application/json" \
           -d "$requestBody" \
-          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices" | jq -r '.testMatrixId')`
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices")`
 
           echo "Test Matrix ID: $matrixId"
           echo "::set-output name=testMatrixId::$matrixId"

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -142,7 +142,8 @@ jobs:
                 "gcsPath": "gs://$${{ steps.generate-dir.outputs.bucket }}/$${{ steps.generate-dir.outputs.results_dir }}"
               }
             }
-          
+          }
+          '
           
           responseBody=$(curl -X POST \
           -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - name: Checkout
+        with:
+          token: ${{secrets.FIREBASE_PROJECT_ID }}
         uses: actions/checkout@v3
 
       - name: Set up Python
@@ -81,15 +83,46 @@ jobs:
           echo "results_dir=$(date +%F_%T)-${RANDOM}" >> "$GITHUB_OUTPUT"
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
 
-      - name: Run tests on Firebase Test Lab
-        id: run_tests
-        run: |-
-          output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}")
-          echo "Running tests on Firebase Test Lab... -Output: $output.
-          Now I am trying to extract testMatrixId. "
-          testMatrixId=$(echo "$output" | grep -oP "matrix-(\w+)")
-          echo "::set-output name=testMatrixId::$testMatrixId"
-          echo "::set-output name=testMatrixId::$testMatrixId" >> test_matrix_id.txt
+
+      - name: Create Firebase Test Lab Matrix
+        run: |
+          # Define the necessary variables
+          projectId=${{ secrets.FIREBASE_PROJECT_ID }}
+          accessToken=${{ secrets.SERVICE_ACCOUNT }}
+          
+          # Define the request body for creating the test matrix
+          requestBody='{
+            "environmentMatrix": {
+              "androidDeviceList": {
+                "androidDevices": [
+                    {
+                      "model": "Pixel2",
+                      "version": "30",
+                      "locale": "en",
+                      "orientation": "portrait"
+                    }
+                ]
+              },
+            "testSpecification": {
+              "androidInstrumentationTest": {
+                "appApk": "app/build/outputs/apk/debug/app-debug.apk",
+                "testApk": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+              }
+            },
+          "resultsStorage": {
+                "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
+            }
+          }'
+          
+          # Make the request to create the test matrix
+          matrixId=$(curl -X POST \
+            -H "Authorization: Bearer $accessToken" \
+            -H "Content-Type: application/json" \
+            -d "$requestBody" \
+            "https://testing.googleapis.com/v1/projects/$projectId/testMatrices" | jq -r '.testMatrixId')
+          
+          echo "Test Matrix ID: $matrixId"
+          echo "::set-output name=testMatrixId::$matrixId"
 
       - name: Upload test matrix ID artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -159,6 +159,7 @@ jobs:
           fi
 
       - name: Check for the test status x2
+        if: always()
         run: |
           sleep 100
           

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -93,8 +93,8 @@ jobs:
 
       - name: Upload APK to GCS
         run: |
-          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs://${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
-          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs://${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
+          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
+          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
 
 
       - name: Set up Cloud SDK

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -88,7 +88,6 @@ jobs:
       - name: Create Firebase Test Lab Matrix
         run: |
           # Define the necessary variables
-          accessToken=${{ secrets.SERVICE_ACCOUNT }}
           echo "Hello"
                  
         

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -63,15 +63,15 @@ jobs:
         run: echo "::set-output name=testMatrixId::$(cat test_matrix_id.txt)"
 
       - name: Cancel previous test run on Firebase Test Lab
-        if: steps.run_tests.outputs.testMatrixId != ''
+        if: steps.previous_test_matrix.outputs.testMatrixId != ''
         run: |
           gcloud firebase test android matrices cancel ${{ steps.previous_test_matrix.outputs.testMatrixId }}
 
-      # - name: Prepare Android Environment
-      #   uses: ./.github/actions/prepare-android-env
+      - name: Prepare Android Environment
+        uses: ./.github/actions/prepare-android-env
 
-      #- name: Assemble App Debug APK and Android Instrumentation Tests
-      # run: ./gradlew assembleDebug assembleDebugAndroidTest
+      - name: Assemble App Debug APK and Android Instrumentation Tests
+        run: ./gradlew assembleDebug assembleDebugAndroidTest
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -115,10 +115,10 @@ jobs:
           echo "Service account: ${{secrets.SERVICE_ACCOUNT}} "
           echo "Firebase project id: ${{secrets.FIREBASE_PROJECT_ID}}" 
 
-          matrixId=$(curl -X POST \
+          matrixId=`(curl -X POST \
           -H "Content-Type: application/json" \
           -d "$requestBody" \
-          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices" | jq -r '.testMatrixId')
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices" | jq -r '.testMatrixId')`
 
           echo "Test Matrix ID: $matrixId"
           echo "::set-output name=testMatrixId::$matrixId"

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -142,7 +142,7 @@ jobs:
           responseBody=$(curl -X GET \
           -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
           -H "Content-Type: application/json" \
-          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices/${{steps.tests.testMatrixId}}"/)
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices/${{steps.tests.outputs.testMatrixId}}"/)
           
           echo "Test Matrix response body from get: $responseBody"
 

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -87,7 +87,42 @@ jobs:
 
       - name: Create Firebase Test Lab Matrix
         run: |
-          echo "Hello"
+          projectId=${{ secrets.FIREBASE_PROJECT_ID }}
+          accessToken=${{ secrets.SERVICE_ACCOUNT }}
+
+          requestBody='{
+          "environmentMatrix": {
+          "androidDeviceList": {
+          "androidDevices": [
+          {
+            "model": "Pixel2",
+            "version": "30",
+            "locale": "en",
+            "orientation": "portrait"
+          }
+          ]
+          }
+          },
+          "testSpecification": {
+          "androidInstrumentationTest": {
+          "appApk": "app/build/outputs/apk/debug/app-debug.apk",
+          "testApk": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+          }
+          },
+          "resultsStorage": {
+          "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
+          }
+          }'
+
+          matrixId=$(curl -X POST \
+          -H "Authorization: Bearer $accessToken" \
+          -H "Content-Type: application/json" \
+          -d "$requestBody" \
+          "https://testing.googleapis.com/v1/projects/$projectId/testMatrices" | jq -r '.testMatrixId')
+
+          echo "Test Matrix ID: $matrixId"
+          echo "::set-output name=testMatrixId::$matrixId"
+
 
       - name: Upload test matrix ID artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -90,34 +90,9 @@ jobs:
           # Define the necessary variables
           projectId=${{ secrets.FIREBASE_PROJECT_ID }}
           accessToken=${{ secrets.SERVICE_ACCOUNT }}
-
-          # Define the request body for creating the test matrix
-          requestBody='{
-            "environmentMatrix": {
-              "androidDeviceList": {
-                "androidDevices": [
-                    {
-                      "model": "Pixel2",
-                      "version": "30",
-                      "locale": "en",
-                      "orientation": "portrait"
-                    }
-                ]
-              }
-            },
-            "testSpecification": {
-              "androidInstrumentationTest": {
-                "appApk": "app/build/outputs/apk/debug/app-debug.apk",
-                "testApk": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-              }
-            },
-            "resultsStorage": {
-              "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
-            }
-          }'
-
-          # Make the request to create the test matrix
-                  
+                 
+        
+        
         
         # echo "Test Matrix ID: $matrixId"
         #echo "::set-output name=testMatrixId::$matrixId"

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -88,8 +88,8 @@ jobs:
       - name: Create Firebase Test Lab Matrix
         run: |
           # Define the necessary variables
-          projectId=${{ secrets.FIREBASE_PROJECT_ID }}
           accessToken=${{ secrets.SERVICE_ACCOUNT }}
+          echo "Hello"
                  
         
         

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -111,14 +111,11 @@ jobs:
           }
           }'
           
-          echo "$requestBody" > requestBody.json
-          echo "Service account: ${{secrets.SERVICE_ACCOUNT}} "
-          echo "Firebase project id: ${{secrets.FIREBASE_PROJECT_ID}}" 
-
-          matrixId=`(curl -X POST \
+          matrixId=$(curl -X POST \
+          -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
           -H "Content-Type: application/json" \
           -d "$requestBody" \
-          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices")`
+          "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices" | jq -r '.testMatrixId')
 
           echo "Test Matrix ID: $matrixId"
           echo "::set-output name=testMatrixId::$matrixId"

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -67,6 +67,7 @@ jobs:
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
 
       - name: Run tests on Firebase Test Lab
+        id: run_tests
         run: |-
           output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}")
           testMatrixId=$(echo "$output" | grep -oP "Test \[matrix-\K[^]]+")

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -39,39 +39,61 @@ jobs:
         with:
           credentials_json: ${{ secrets.SERVICE_ACCOUNT }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
       - name: Get previous workflow run details
         id: get_previous_run
-        uses: actions/github-script@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { Octokit } = require("@octokit/rest");
-            const octokit = new Octokit();
+        run: |
+          import os
+          import requests
 
-            const { owner, repo } = context.repo;
-            const workflowName = 'Android Release'; // Replace with your workflow name
-            const perPage = 1; // Number of workflow runs to fetch
+          github_token = os.getenv('GITHUB_TOKEN')
+          owner = os.getenv('GITHUB_REPOSITORY_OWNER')
+          repo = os.getenv('GITHUB_REPOSITORY')
+          workflow_name = 'Android Release'  # Replace with your workflow name
+          per_page = 1  # Number of workflow runs to fetch
 
-            // Get the previous workflow run
-            const response = await octokit.rest.actions.listWorkflowRuns({
-              owner,
-              repo,
-              workflow_name: workflowName,
-              per_page: perPage
-            });
+          headers = {
+              'Authorization': f'Bearer {github_token}',
+              'Accept': 'application/vnd.github.v3+json'
+          }
 
-            if (response.data.total_count > 0) {
-              const previousRun = response.data.workflow_runs[0];
-              console.log(`Previous workflow run ID: ${previousRun.id}`);
-              console.log(`Previous workflow run status: ${previousRun.status}`);
+          # Get the previous workflow run details
+          response = requests.get(
+              f'https://api.github.com/repos/{owner}/{repo}/actions/workflows',
+              headers=headers,
+              params={'per_page': per_page}
+          )
+          response.raise_for_status()
+          data = response.json()
 
-              // Extract testMatrixId from the workflow run details
-              const testMatrixId = previousRun.workflow_job_runs[0].outputs.testMatrixId;
-              console.log(`Previous testMatrixId: ${testMatrixId}`);
-              core.setOutput('testMatrixId', testMatrixId);
-            } else {
-              console.log('No previous workflow runs found.');
-            }
+          if data['total_count'] > 0:
+              previous_run = data['workflows'][0]
+              print(f"Previous workflow run ID: {previous_run['id']}")
+              print(f"Previous workflow run status: {previous_run['status']}")
+
+              # Get the workflow job runs for the previous run
+              job_runs_response = requests.get(
+                  f'https://api.github.com/repos/{owner}/{repo}/actions/runs/{previous_run["id"]}/jobs',
+                  headers=headers
+              )
+              job_runs_response.raise_for_status()
+              job_runs_data = job_runs_response.json()
+
+              # Extract the testMatrixId from the workflow job runs
+              test_matrix_id = next(
+                  (step['outputs']['testMatrixId'] for job in job_runs_data['jobs'] for step in job['steps'] if step['name'] == 'Run tests on Firebase Test Lab'),
+                  None
+              )
+              print(f"Previous testMatrixId: {test_matrix_id}")
+
+              # Set the output variable
+              print(f"::set-output name=testMatrixId::{test_matrix_id}")
+          else:
+              print("No previous workflow runs found.")
 
       - name: Cancel previous test run on Firebase Test Lab
         if: steps.get_previous_run.outputs.testMatrixId != ''

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -44,61 +44,10 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Get previous workflow run details
-        id: get_previous_run
-        run: |
-          import os
-          import requests
-
-          github_token = os.getenv('GITHUB_TOKEN')
-          owner = os.getenv('GITHUB_REPOSITORY_OWNER')
-          repo = os.getenv('GITHUB_REPOSITORY')
-          workflow_name = 'Android Release'  # Replace with your workflow name
-          per_page = 1  # Number of workflow runs to fetch
-
-          headers = {
-              'Authorization': f'Bearer {github_token}',
-              'Accept': 'application/vnd.github.v3+json'
-          }
-
-          # Get the previous workflow run details
-          response = requests.get(
-              f'https://api.github.com/repos/{owner}/{repo}/actions/workflows',
-              headers=headers,
-              params={'per_page': per_page}
-          )
-          response.raise_for_status()
-          data = response.json()
-
-          if data['total_count'] > 0:
-              previous_run = data['workflows'][0]
-              print(f"Previous workflow run ID: {previous_run['id']}")
-              print(f"Previous workflow run status: {previous_run['status']}")
-
-              # Get the workflow job runs for the previous run
-              job_runs_response = requests.get(
-                  f'https://api.github.com/repos/{owner}/{repo}/actions/runs/{previous_run["id"]}/jobs',
-                  headers=headers
-              )
-              job_runs_response.raise_for_status()
-              job_runs_data = job_runs_response.json()
-
-              # Extract the testMatrixId from the workflow job runs
-              test_matrix_id = next(
-                  (step['outputs']['testMatrixId'] for job in job_runs_data['jobs'] for step in job['steps'] if step['name'] == 'Run tests on Firebase Test Lab'),
-                  None
-              )
-              print(f"Previous testMatrixId: {test_matrix_id}")
-
-              # Set the output variable
-              print(f"::set-output name=testMatrixId::{test_matrix_id}")
-          else:
-              print("No previous workflow runs found.")
-
       - name: Cancel previous test run on Firebase Test Lab
         if: steps.get_previous_run.outputs.testMatrixId != ''
         run: |
-          gcloud firebase test android matrices cancel ${{ steps.get_previous_run.outputs.testMatrixId }}
+          gcloud firebase test android matrices cancel ${{ steps.test_lab_testing.outputs.testMatrixId }}
 
       - name: Prepare Android Environment
         uses: ./.github/actions/prepare-android-env
@@ -118,8 +67,12 @@ jobs:
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
 
       - name: Run tests on Firebase Test Lab
+        id: test_lab_testing
         run: |-
-          gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}"
+          output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}" --format=json)
+          testMatrixId=$(echo "$output" | jq -r '.testMatrixId')
+          echo "testMatrixId: $testMatrixId"
+          echo "::set-output name=testMatrixId::$testMatrixId"
 
       - name: Upload to Big Query
         if: always()

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
       - name: Install Python dependencies
         uses: py-actions/py-dependency-install@v4
         with:

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -87,15 +87,7 @@ jobs:
 
       - name: Create Firebase Test Lab Matrix
         run: |
-          # Define the necessary variables
           echo "Hello"
-                 
-        
-        
-        
-        # echo "Test Matrix ID: $matrixId"
-        #echo "::set-output name=testMatrixId::$matrixId"
-      
 
       - name: Upload test matrix ID artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -66,15 +66,11 @@ jobs:
           echo "results_dir=$(date +%F_%T)-${RANDOM}" >> "$GITHUB_OUTPUT"
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
 
-      - name: Print help
-        if: always()
+      - name: Run tests on Firebase Test Lab
         run: |-
-          gcloud help firebase test android run
-
-      - name: Pring help x2
-        if: always()
-        run: |-
-          gcloud firebase test android run --help
+          output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}")
+          testMatrixId=$(echo "$output" | grep -oP "Test \[matrix-\K[^]]+")
+          echo "::set-output name=testMatrixId::$testMatrixId"
 
       - name: Upload to Big Query
         if: always()

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -88,33 +88,34 @@ jobs:
       - name: Create Firebase Test Lab Matrix
         run: |
           requestBody='{
-          "environmentMatrix": {
-          "androidDeviceList": {
-          "androidDevices": [
-          {
-            "androidModelId": "Pixel2",
-            "androidVersionId": "30",
-            "locale": "en",
-            "orientation": "portrait"
-          }
-          ]
-          }
-          },
-          "testSpecification": {
-          "androidInstrumentationTest": {
-            "testApk":{
-              "gcsPath": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+            "environmentMatrix": {
+              "androidDeviceList": {
+                "androidDevices": [
+                  {
+                    "androidModelId": "Pixel2",
+                    "androidVersionId": "30",
+                    "locale": "en",
+                    "orientation": "portrait"
+                  }
+                ]
               }
-           "appApk":{
-              "gcsPath": "app/build/outputs/apk/debug/app-debug.apk"
+            },
+            "testSpecification": {
+              "androidInstrumentationTest": {
+                "testApk": {
+                  "gcsPath": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+                },
+                "appApk": {
+                  "gcsPath": "app/build/outputs/apk/debug/app-debug.apk"
+                }
               }
-          }
-          },
-          "resultsStorage": {
-            "googleCloudStorage": {
+            },
+            "resultsStorage": {
+              "googleCloudStorage": {
                 "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
+              }
             }
-            }'
+          }'
           
           responseBody=$(curl -X POST \
           -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -45,9 +45,9 @@ jobs:
           python-version: 3.x
 
       - name: Cancel previous test run on Firebase Test Lab
-        if: steps.get_previous_run.outputs.testMatrixId != ''
+        if: steps.run_tests.outputs.testMatrixId != ''
         run: |
-          gcloud firebase test android matrices cancel ${{ steps.test_lab_testing.outputs.testMatrixId }}
+          gcloud firebase test android matrices cancel ${{ steps.run_tests.outputs.testMatrixId }}
 
       - name: Prepare Android Environment
         uses: ./.github/actions/prepare-android-env
@@ -67,12 +67,13 @@ jobs:
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
 
       - name: Run tests on Firebase Test Lab
-        id: test_lab_testing
+        id: run_tests
         run: |-
           output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}" --format=json)
-          testMatrixId=$(echo "$output" | jq -r '.testMatrixId')
+          testMatrixId=$(echo "$output" | python -c "import sys, json; data=json.load(sys.stdin); print(data['testMatrixId'][0])")
           echo "testMatrixId: $testMatrixId"
           echo "::set-output name=testMatrixId::$testMatrixId"
+
 
       - name: Upload to Big Query
         if: always()

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -73,6 +73,25 @@ jobs:
       - name: Assemble App Debug APK and Android Instrumentation Tests
         run: ./gradlew assembleDebug assembleDebugAndroidTest
 
+      - name: Check APK file existence
+        run: |
+          if [ -f app/build/outputs/apk/debug/app-debug.apk ]; then
+            echo "APK file exists."
+          else
+            echo "APK file does not exist."
+            exit 1
+          fi
+
+      - name: Check APK file permissions
+        run: |
+          if [ -r app/build/outputs/apk/debug/app-debug.apk ]; then
+            echo "APK file has read permissions."
+          else
+            echo "APK file does not have read permissions."
+            exit 1
+          fi
+
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:
@@ -106,6 +125,7 @@ jobs:
                 "testApk": {
                   "gcsPath": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
                 },
+                "appPackageId": "com.appunite.loudius",
                 "appApk": {
                   "gcsPath": "app/build/outputs/apk/debug/app-debug.apk"
                 }

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -85,6 +85,7 @@ jobs:
         id: run_tests
         run: |-
           output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}")
+          echo "Running tests on Firebase Test Lab... -Output: $output. Now I am trying to extract testMatrixId. "
           testMatrixId=$(echo "$output" | grep -oP "matrix-(\w+)")
           echo "::set-output name=testMatrixId::$testMatrixId"
 

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -66,14 +66,15 @@ jobs:
           echo "results_dir=$(date +%F_%T)-${RANDOM}" >> "$GITHUB_OUTPUT"
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
 
-      - name: Run tests on Firebase Test Lab
-        id: run_tests
+      - name: Print help
+        if: always()
         run: |-
-          output=$(gcloud firebase test android run ".github/tests.yml:android-pixel-2" --results-dir="${{ steps.generate-dir.outputs.results_dir }}" --results-bucket="${{ steps.generate-dir.outputs.bucket }}" --format=json)
-          testMatrixId=$(echo "$output" | python -c "import sys, json; data=json.load(sys.stdin); print(data['testMatrixId'][0])")
-          echo "testMatrixId: $testMatrixId"
-          echo "::set-output name=testMatrixId::$testMatrixId"
+          gcloud help firebase test android run
 
+      - name: Pring help x2
+        if: always()
+        run: |-
+          gcloud firebase test android run --help
 
       - name: Upload to Big Query
         if: always()

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -124,7 +124,7 @@ jobs:
           "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices")
 
           echo "Test Matrix response body: $responseBody"
-          test_matrix_id=$(echo "responseBody" | jq -r '.testMatrixId')
+          test_matrix_id=$(echo "$responseBody" | jq -r '.testMatrixId')
           
           echo "Test Matrix ID: $test_matrix_id"
           echo $test_matrix_id > test_matrix_id.txt

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -103,10 +103,9 @@ jobs:
           echo "results_dir=$(date +%F_%T)-${RANDOM}" >> "$GITHUB_OUTPUT"
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
 
-      - name: Create directories on GCS
+      - name: Create directory on GCS
         run: |
-          gsutil mb gs://${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest
-          gsutil mb gs://${{ steps.generate-dir.outputs.bucket }}/app-debug
+          gsutil mb gs://${{ steps.generate-dir.outputs.bucket }}
 
       - name: Upload APK to GCS
         run: |

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -129,20 +129,20 @@ jobs:
             "testSpecification": {
               "androidInstrumentationTest": {
                 "testApk": {
-                  "gcsPath": gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
+                  "gcsPath": "gs://$${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk"
                 },
                 "appPackageId": "com.appunite.loudius",
                 "appApk": {
-                  "gcsPath": gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
+                  "gcsPath": "gs://$${{ steps.generate-dir.outputs.bucket }}/app-debug.apk"
                 }
               }
             },
             "resultStorage": {
               "googleCloudStorage": {
-                "gcsPath": "gs:/${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
+                "gcsPath": "gs://$${{ steps.generate-dir.outputs.bucket }}/$${{ steps.generate-dir.outputs.results_dir }}"
               }
             }
-          }'
+          
           
           responseBody=$(curl -X POST \
           -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -110,6 +110,10 @@ jobs:
           "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
           }
           }'
+          
+          echo "$requestBody" > requestBody.json
+          echo "Service account: ${{secrets.SERVICE_ACCOUNT}} "
+          echo "Firebase project id: ${{secrets.FIREBASE_PROJECT_ID}}" 
 
           matrixId=$(curl -X POST \
           -H "Authorization: Bearer ${{ secrets.SERVICE_ACCOUNT }}" \

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -92,8 +92,8 @@ jobs:
           "androidDeviceList": {
           "androidDevices": [
           {
-            "model": "Pixel2",
-            "version": "30",
+            "androidModelId": "Pixel2",
+            "androidVersionId": "30",
             "locale": "en",
             "orientation": "portrait"
           }
@@ -102,22 +102,27 @@ jobs:
           },
           "testSpecification": {
           "androidInstrumentationTest": {
-          "appApk": "app/build/outputs/apk/debug/app-debug.apk",
-          "testApk": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+            "testApk":{
+              "gcsPath": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+              }
+           "appApk":{
+              "gcsPath": "app/build/outputs/apk/debug/app-debug.apk"
+              }
           }
           },
           "resultsStorage": {
-          "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
-          }
-          }'
+            "googleCloudStorage": {
+                "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
+            }
+            }'
           
-          matrixId=$(curl -X POST \
+          responseBody=$(curl -X POST \
           -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
           -H "Content-Type: application/json" \
           -d "$requestBody" \
           "https://testing.googleapis.com/v1/projects/${{ secrets.FIREBASE_PROJECT_ID }}/testMatrices")
 
-          echo "Test Matrix ID: $matrixId"
+          echo "Test Matrix response body: $responseBody"
           echo "::set-output name=testMatrixId::$matrixId"
 
 

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -91,6 +91,11 @@ jobs:
             exit 1
           fi
 
+      - name: Upload APK to GCS
+        run: |
+          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs://${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
+          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs://${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
+
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
@@ -123,11 +128,11 @@ jobs:
             "testSpecification": {
               "androidInstrumentationTest": {
                 "testApk": {
-                  "gcsPath": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+                  "gcsPath": gs://${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
                 },
                 "appPackageId": "com.appunite.loudius",
                 "appApk": {
-                  "gcsPath": "app/build/outputs/apk/debug/app-debug.apk"
+                  "gcsPath": gs://${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
                 }
               }
             },

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -117,12 +117,8 @@ jobs:
           }'
 
           # Make the request to create the test matrix
-          matrixId=$(curl -X POST \
-            -H "Authorization: Bearer $accessToken" \
-            -H "Content-Type: application/json" \
-            -d "$requestBody" \
-            "https://testing.googleapis.com/v1/projects/$projectId/testMatrices" | jq -r '.testMatrixId')
-
+                  
+        
         # echo "Test Matrix ID: $matrixId"
         #echo "::set-output name=testMatrixId::$matrixId"
       

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -87,7 +87,7 @@ jobs:
           # Define the necessary variables
           projectId=${{ secrets.FIREBASE_PROJECT_ID }}
           accessToken=${{ secrets.SERVICE_ACCOUNT }}
-          
+
           # Define the request body for creating the test matrix
           requestBody='{
             "environmentMatrix": {
@@ -100,27 +100,29 @@ jobs:
                       "orientation": "portrait"
                     }
                 ]
-              },
+              }
+            },
             "testSpecification": {
               "androidInstrumentationTest": {
                 "appApk": "app/build/outputs/apk/debug/app-debug.apk",
                 "testApk": "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
               }
             },
-          "resultsStorage": {
-                "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
+            "resultsStorage": {
+              "gcsPath": "gs://${{ steps.generate-dir.outputs.bucket }}/${{ steps.generate-dir.outputs.results_dir }}"
             }
           }'
-          
+
           # Make the request to create the test matrix
           matrixId=$(curl -X POST \
             -H "Authorization: Bearer $accessToken" \
             -H "Content-Type: application/json" \
             -d "$requestBody" \
             "https://testing.googleapis.com/v1/projects/$projectId/testMatrices" | jq -r '.testMatrixId')
-          
+
           echo "Test Matrix ID: $matrixId"
           echo "::set-output name=testMatrixId::$matrixId"
+      
 
       - name: Upload test matrix ID artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -67,11 +67,11 @@ jobs:
         run: |
           gcloud firebase test android matrices cancel ${{ steps.previous_test_matrix.outputs.testMatrixId }}
 
-      - name: Prepare Android Environment
-        uses: ./.github/actions/prepare-android-env
+      # - name: Prepare Android Environment
+      #   uses: ./.github/actions/prepare-android-env
 
-      - name: Assemble App Debug APK and Android Instrumentation Tests
-        run: ./gradlew assembleDebug assembleDebugAndroidTest
+      #- name: Assemble App Debug APK and Android Instrumentation Tests
+      # run: ./gradlew assembleDebug assembleDebugAndroidTest
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
@@ -123,8 +123,8 @@ jobs:
             -d "$requestBody" \
             "https://testing.googleapis.com/v1/projects/$projectId/testMatrices" | jq -r '.testMatrixId')
 
-          echo "Test Matrix ID: $matrixId"
-          echo "::set-output name=testMatrixId::$matrixId"
+        # echo "Test Matrix ID: $matrixId"
+        #echo "::set-output name=testMatrixId::$matrixId"
       
 
       - name: Upload test matrix ID artifact

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -102,12 +102,18 @@ jobs:
         run: |-
           echo "results_dir=$(date +%F_%T)-${RANDOM}" >> "$GITHUB_OUTPUT"
           echo "bucket=test-lab-07qs3ns6c51bi-iazpthysivhkq" >> "$GITHUB_OUTPUT"
+          
+          gsutil mb gs://app-debug.apk
 
+      - name: Create directories on GCS
+        run: |
+          gsutil mb gs://${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest
+          gsutil mb gs://${{ steps.generate-dir.outputs.bucket }}/app-debug
 
       - name: Upload APK to GCS
         run: |
-          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug.apk
-          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest.apk
+          gsutil cp app/build/outputs/apk/debug/app-debug.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug
+          gsutil cp app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk gs:/${{ steps.generate-dir.outputs.bucket }}/app-debug-androidTest
 
 
 

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -39,6 +39,45 @@ jobs:
         with:
           credentials_json: ${{ secrets.SERVICE_ACCOUNT }}
 
+      - name: Get previous workflow run details
+        id: get_previous_run
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { Octokit } = require("@octokit/rest");
+            const octokit = new Octokit();
+
+            const { owner, repo } = context.repo;
+            const workflowName = 'Android Release'; // Replace with your workflow name
+            const perPage = 1; // Number of workflow runs to fetch
+
+            // Get the previous workflow run
+            const response = await octokit.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_name: workflowName,
+              per_page: perPage
+            });
+
+            if (response.data.total_count > 0) {
+              const previousRun = response.data.workflow_runs[0];
+              console.log(`Previous workflow run ID: ${previousRun.id}`);
+              console.log(`Previous workflow run status: ${previousRun.status}`);
+
+              // Extract testMatrixId from the workflow run details
+              const testMatrixId = previousRun.workflow_job_runs[0].outputs.testMatrixId;
+              console.log(`Previous testMatrixId: ${testMatrixId}`);
+              core.setOutput('testMatrixId', testMatrixId);
+            } else {
+              console.log('No previous workflow runs found.');
+            }
+
+      - name: Cancel previous test run on Firebase Test Lab
+        if: steps.get_previous_run.outputs.testMatrixId != ''
+        run: |
+          gcloud firebase test android matrices cancel ${{ steps.get_previous_run.outputs.testMatrixId }}
+
       - name: Prepare Android Environment
         uses: ./.github/actions/prepare-android-env
 

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -7,6 +7,10 @@ on:
       - "develop"
       - "main"
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -15,6 +15,7 @@ permissions: read-all
 
 jobs:
   unit-tests:
+    if: false # Set to true to enable this job
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
### Why? 
To save money on Firebase by stopping tests on Firebase if the new one has already started. 

### Changes:
- Instead of the Google CLI command for starting tests `run` used `create` from Firebase REST API. That is needed because `run` doesn't return `testMatrixID` as soon as the test execution starts. `TestMatrixId` is required for a `cancel` request which stops running tests. 

### Sources
https://firebase.google.com/docs/test-lab/reference/testing/rest/v1/projects.testMatrices/create
https://firebase.google.com/docs/test-lab/reference/testing/rest/v1/projects.testMatrices

### CLOSING REASON
I spent much time trying to do so, but without success. There is still much work to do, but the possible value we could get is not so big. 
In the present state of the branch, there is a problem with the GCS bucket. And there could be more potential issues like: 
- 'create' makes only a request for creating tests and then we move to the next step in the workflow. Because of that, it would be required to figure out a way on uploading test results after tests finish. 

