### PR TITLE
[fix LD-106] add name for screenshot

### DIFF
--- a/app/src/androidTest/java/com/appunite/loudius/util/ScreenshotTestRule.kt
+++ b/app/src/androidTest/java/com/appunite/loudius/util/ScreenshotTestRule.kt
@@ -50,7 +50,7 @@ open class ScreenshotTestRule : TestRule {
                     return
                 } catch (t: Throwable) {
                     if (!errorHandled.get()) {
-                        Screenshot.capture().process()
+                        captureScreenshot(description)
                     }
                     error = t
                 }
@@ -58,5 +58,11 @@ open class ScreenshotTestRule : TestRule {
                 if (error != null) throw error
             }
         }
+    }
+
+    private fun captureScreenshot(description: Description) {
+        val screenshot = Screenshot.capture()
+        screenshot.name = "${description.testClass.simpleName}_${description.methodName}-failure"
+        screenshot.process()
     }
 }


### PR DESCRIPTION
Adding the name of the screenshot when the test fails.