### PR TITLE
[LD-108] Ensure orphan Github Actions are cancelled, when new pull-request is pushed

### DIFF
--- a/.github/actions/prepare-android-env/action.yml
+++ b/.github/actions/prepare-android-env/action.yml
@@ -3,11 +3,6 @@ description: "Cancels previous runs, set ups jdk, validates gradle wrapper and u
 runs:
   using: "composite"
   steps:
-    - name: Cancel previous runs for the same branch
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
-
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/run-snapshot-test.yml
+++ b/.github/workflows/run-snapshot-test.yml
@@ -4,6 +4,10 @@ name: Snapshot verification
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   checks: write
   contents: write

--- a/.github/workflows/run-ui-test.yml
+++ b/.github/workflows/run-ui-test.yml
@@ -14,6 +14,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   apk:
     name: Run UI tests on Firebase Test Lab

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -7,6 +7,10 @@ on:
       - "develop"
       - "main"
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
## Why? 
If GitHub Actions are not cancelled, this increases the costs of CI. If we ensure those that are orphans are cancelled, we will decrease CI costs.
[[LD-108] ](https://loudius.atlassian.net/jira/software/projects/LD/boards/3/backlog?epics=visible&selectedIssue=LD-108)

## Changes: 
- Added concurrency rule for run-ui-test workflow
- Removed cancel workflow action from prepare-android-env action since it sometimes didn't work (see image below). Used concurrency instead. 

![image](https://github.com/appunite/Loudius/assets/33498031/41847a8e-5a2d-46fb-a85b-9dd30b7329ee)

## Note: 
Tests on Firebase won't be cancelled. Due to implementing that is very time-consuming it wasn't finished. #107  I've created a separate task for that in the backlog so that we have it in mind. [LD-110](https://loudius.atlassian.net/browse/LD-110)

## Test
See previous actions. All from previous run are cancelled. 
![image](https://github.com/appunite/Loudius/assets/33498031/8ef42c5e-5099-4c35-a93f-94c5d0fa9eeb)
