### PR TITLE
[LD-105] Add additional workflow for notifying on slack about workflow failure.

### DIFF
--- a/.github/workflows/check-for-workflow-failure.yml
+++ b/.github/workflows/check-for-workflow-failure.yml
@@ -1,0 +1,22 @@
+name: Check for master or prod failure
+on:
+  workflow_run:
+    workflows: [ "MegaLinter", "Snapshot recording", "Snapshot verification", "Android Release", "Run unit tests" ]
+    types: [ completed ]
+
+jobs:
+  on-failure:
+    name: Notify Slack on failure
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: loudius-internal
+          SLACK_COLOR: #C73E1D
+          SLACK_MESSAGE: 'Test message - Failure on develop or master branch :cry:'
+          SLACK_TITLE: Workflow failure
+          SLACK_USERNAME: Failure bot

--- a/.github/workflows/check-for-workflow-failure.yml
+++ b/.github/workflows/check-for-workflow-failure.yml
@@ -17,6 +17,6 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: loudius-internal
           SLACK_COLOR: #C73E1D
-          SLACK_MESSAGE: 'Test message - Failure on develop or master branch :cry:'
+          SLACK_MESSAGE: "Failure on ${{ github.event.workflow_run.branch.name }} branch for ${{ github.event.workflow_run.workflow }}:cry:"
           SLACK_TITLE: Workflow failure
           SLACK_USERNAME: Failure bot

--- a/.github/workflows/check-for-workflow-failure.yml
+++ b/.github/workflows/check-for-workflow-failure.yml
@@ -1,8 +1,15 @@
 name: Check for master or prod failure
 on:
   workflow_run:
-    workflows: [ "MegaLinter", "Snapshot recording", "Snapshot verification", "Android Release", "Run unit tests" ]
-    types: [ completed ]
+    workflows:
+      [
+        "MegaLinter",
+        "Snapshot recording",
+        "Snapshot verification",
+        "Android Release",
+        "Run unit tests",
+      ]
+    types: [completed]
 
 permissions: read-all
 

--- a/.github/workflows/check-for-workflow-failure.yml
+++ b/.github/workflows/check-for-workflow-failure.yml
@@ -4,19 +4,23 @@ on:
     workflows: [ "MegaLinter", "Snapshot recording", "Snapshot verification", "Android Release", "Run unit tests" ]
     types: [ completed ]
 
+permissions: read-all
+
 jobs:
   on-failure:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: loudius-internal
-          SLACK_COLOR: #C73E1D
+          SLACK_COLOR: "#C73E1D"
           SLACK_MESSAGE: "Failure on ${{ github.event.workflow_run.branch.name }} branch for ${{ github.event.workflow_run.workflow }}:cry:"
           SLACK_TITLE: Workflow failure
           SLACK_USERNAME: Failure bot

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -1,4 +1,4 @@
-name: "Run unit tests"
+name: Run unit tests
 
 on:
   pull_request:


### PR DESCRIPTION
## Why? 
If we implement a slack notification, we won’t forget about failures after change is merged. [LD-105
](https://loudius.atlassian.net/jira/software/projects/LD/boards/3?selectedIssue=LD-105)

## Changes: 
- Added one additional workflow which notifies Slack if any of the workflows fails.  For now, it will be launched on every workflow fail so I could test it (The following workflow is not working till it is merged on develop). 