### PR TITLE
LD-81 Check license header

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -103,6 +103,21 @@ jobs:
             */build/test-results/**
           retention-days: 5
 
+  test-license-headers:
+    name: Ensure license headers are added
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Ensure license headers are added
+        run: python "build-tools/check-license-headers.py"
+
   test-results:
     name: Upload tests results
     runs-on: ubuntu-20.04

--- a/app/src/test/java/com/appunite/loudius/fakes/FakeUserLocalDataSource.kt
+++ b/app/src/test/java/com/appunite/loudius/fakes/FakeUserLocalDataSource.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 AppUnite S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.appunite.loudius.fakes
 
 import com.appunite.loudius.domain.store.UserLocalDataSource

--- a/build-tools/check-license-headers.py
+++ b/build-tools/check-license-headers.py
@@ -1,0 +1,56 @@
+import fnmatch
+import re
+import sys
+import typing
+import subprocess
+
+
+def get_tracked_files() -> typing.List[str]:
+    """Returns a list of all files tracked by Git."""
+
+    cmd = ["git", "ls-files"]
+    output = subprocess.check_output(cmd).decode("utf-8")
+    return output.splitlines()
+
+
+def check_license(file: str) -> bool:
+    with open(file, "r") as f:
+        contents = f.read()
+        return "Licensed under the Apache License" in contents
+
+
+matchers = [
+    re.compile(fnmatch.translate('*.kt')),
+    re.compile(fnmatch.translate('*.py')),
+]
+
+
+def should_check(file: str) -> bool:
+    for matcher in matchers:
+        if matcher.match(file):
+            return True
+    return False
+
+
+def main():
+    files = get_tracked_files()
+
+    errors: typing.List[str] = []
+    for file in files:
+        if should_check(file):
+            if not check_license(file):
+                errors.append(f"❌ File \"{file}\" does not contain the license phrase")
+        else:
+            print(f"ℹ️ Skipping check for \"{file}\"")
+
+    for error in errors:
+        print(error, file=sys.stderr)
+    if errors:
+        exit(1)
+    else:
+        print("✅ All files contain the license phrase")
+        exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/build-tools/check-license-headers.py
+++ b/build-tools/check-license-headers.py
@@ -1,3 +1,17 @@
+# Copyright 2023 AppUnite S.A.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import fnmatch
 import re
 import sys

--- a/build-tools/upload-junit-to-cloud.py
+++ b/build-tools/upload-junit-to-cloud.py
@@ -1,3 +1,17 @@
+# Copyright 2023 AppUnite S.A.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import typing
 
 from google.cloud import bigquery

--- a/components/src/main/java/com/appunite/loudius/components/components/utils/ReferenceDevices.kt
+++ b/components/src/main/java/com/appunite/loudius/components/components/utils/ReferenceDevices.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 AppUnite S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.appunite.loudius.components.components.utils
 
 import androidx.compose.ui.tooling.preview.Devices


### PR DESCRIPTION
## Description
Add GitHub Actions that verifies if license header is added to Kotlin source files.

### Why?
We don’t need to check if the license headers is correctly added, just ensure if someone haven’t forgotten to add it.

### Note
Needs https://github.com/appunite/Loudius/pull/143 before merging

## Links to related issues
- Fixes [LD-81](https://loudius.atlassian.net/browse/LD-81)


## Demo
| Success | Failure |
|-|-|
| ![Screenshot 2023-10-16 at 17 17 18](https://github.com/appunite/Loudius/assets/689211/5c1b01a3-de72-4fb9-8f5e-aa8793d920fc) | ![Screenshot 2023-10-16 at 17 12 25](https://github.com/appunite/Loudius/assets/689211/c3022977-cd14-4eeb-ab41-098a2d597f44) |
| [Link to success](https://github.com/appunite/Loudius/actions/runs/6535668071/job/17745665599?pr=145) | [Link to failure](https://github.com/appunite/Loudius/actions/runs/6535596979/job/17745462991?pr=145) |

## Documentation
- Link to documentation: **Add link here**
- Link to figma: **Add link here**
- **Add here other useful documentation links that are useful for PR reviewer**

## Checklist
<!--- 
All those checkboxes should be marked before submitting the PR
-->

- [x] Functionality covered by unit tests
- [x] I have manually tested if the code works [Demo](https://github.com/appunite/Loudius/actions/runs/6535596979/job/17745462991?pr=145)
