### PR TITLE
LD-135 Fix building develop branch

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -152,7 +152,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          sparse-checkout: build-tools/
+          sparse-checkout: |
+            build-tools/
+            .github/
 
       - name: Download tests results for both jobs
         uses: actions/download-artifact@v3
@@ -192,7 +194,7 @@ jobs:
           fail-on-error: "false"
 
       - name: Include Slack Notification
-        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
+        if: failure() && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
         uses: ./.github/actions/slack-notification
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Description

### Why?
We have on develop the following issue: https://github.com/appunite/Loudius/actions/runs/6575379465
This was caused by: https://github.com/appunite/Loudius/pull/143

### What?
* Fix the root issue by checking out `.github` directory during spare-checkout.
* Fix the issue, by filtering only `failures()` while sending slack notification

## Links to related issues
<!--- 
Add links to related tickets
-->
- Fixes [LD-135](https://loudius.atlassian.net/browse/LD-135)

## Documentation
- [Sparese checkout](https://squidfunk.github.io/mkdocs-material/blog/2023/09/22/using-git-sparse-checkout-for-faster-documentation-builds/#:~:text=GitHub%20Actions,-To%20enable%20git&text=git%20sparse%2Dcheckout%20always%20checks,included%20in%20the%20checkout%20process.)
- [failure() documentation](https://docs.github.com/en/actions/learn-github-actions/expressions#failure)

## Checklist
~- [ ] Functionality covered by unit tests~
~- [ ] I have manually tested if the code works~

To test this we need to merge change to develop branch
