### PR TITLE
[LD-151] Fix coverage report

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -66,6 +66,7 @@ jobs:
             */build/reports/jacoco/codeCoverage/html/**
 
       - name: Add coverage to PR
+        if: always()
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
         with:


### PR DESCRIPTION
# Pull-Request
## Description

### Why?
<!-- Describe why the change is introduced -->
"Add coverage report" job isn't working on scheduled jobs.

### What?
<!-- Add here short description what has changed -->
Added action trigger always.

## Links to related issues
<!--- 
Add links to related tickets
-->
- Fixes [LD-151](https://loudius.atlassian.net/browse/LD-151)

## Demo
<!--- 
Screenshots or video that presents the feature or fix
-->
Nothing to show :)

## How to test
<!--
Add a description that will help reviewer check if given change works as expected
-->
I think we have to wait for scheduled job on develop. If you have any idea how to test it, please give me a hint.

## Documentation
- Found similar issue here: [StackOverflow](https://stackoverflow.com/questions/73299202/trigger-github-action-on-schedule-not-ci-push)

## Checklist
<!--- 
All those checkboxes should be marked before submitting the PR
-->

~- [ ] Functionality is covered by unit tests~
~- [ ] Functionality is covered by integration tests~
- [x] I've updated PR description with relevant information
- [x] I've done self code review
- [x] I've manually tested if the code and app works
