### PR TITLE
[LD-142] Fix slack notifications

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -133,7 +133,7 @@ jobs:
             --results-bucket="${{ steps.generate-dir.outputs.bucket }}" \
             --environment-variables "clearPackageData=true,coverage=true,coverageFilePath=/sdcard/Download/" \
             --directories-to-pull /sdcard/Download
-          exit 10
+          exit 1
 
       - name: Download test results from Firebase Test Lab
         if: always()

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -133,7 +133,6 @@ jobs:
             --results-bucket="${{ steps.generate-dir.outputs.bucket }}" \
             --environment-variables "clearPackageData=true,coverage=true,coverageFilePath=/sdcard/Download/" \
             --directories-to-pull /sdcard/Download
-          exit 1
 
       - name: Download test results from Firebase Test Lab
         if: always()

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -240,6 +240,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: always()
     needs:
+      - android-tests
       - merge
       - verify-formatting
       - test-license-headers

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -288,7 +288,7 @@ jobs:
           fail-on-error: "false"
 
       - name: Include Slack Notification
-        if: failure() && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+        if: failure() && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
         uses: ./.github/actions/slack-notification
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -133,6 +133,7 @@ jobs:
             --results-bucket="${{ steps.generate-dir.outputs.bucket }}" \
             --environment-variables "clearPackageData=true,coverage=true,coverageFilePath=/sdcard/Download/" \
             --directories-to-pull /sdcard/Download
+          exit 10
 
       - name: Download test results from Firebase Test Lab
         if: always()

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -288,7 +288,7 @@ jobs:
           fail-on-error: "false"
 
       - name: Include Slack Notification
-        if: failure() && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+        if: failure() # && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
         uses: ./.github/actions/slack-notification
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -241,7 +241,9 @@ jobs:
     if: always()
     needs:
       - android-tests
+      - unit-tests
       - merge
+      - code-coverage
       - verify-formatting
       - test-license-headers
 
@@ -291,7 +293,7 @@ jobs:
           fail-on-error: "false"
 
       - name: Include Slack Notification
-        if: failure() # && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+        if: always() && contains(needs.*.result, 'failure') # && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
         uses: ./.github/actions/slack-notification
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -154,6 +154,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - android-tests
       - unit-tests

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -292,7 +292,7 @@ jobs:
           fail-on-error: "false"
 
       - name: Include Slack Notification
-        if: always() && contains(needs.*.result, 'failure') # && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+        if: always() && contains(needs.*.result, 'failure') && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
         uses: ./.github/actions/slack-notification
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/app/src/test/java/com/appunite/loudius/ui/reviewers/ReviewersViewModelTest.kt
+++ b/app/src/test/java/com/appunite/loudius/ui/reviewers/ReviewersViewModelTest.kt
@@ -84,7 +84,7 @@ class ReviewersViewModelTest {
 
             expectThat(viewModel.state.data).isA<Data.Success>().and {
                 get(Data.Success::reviewers).containsExactly(
-                    Reviewer(1, "user1", true, 7, 5),
+                    // Reviewer(1, "user1", true, 7, 5),
                     Reviewer(2, "user2", false, 7, null),
                     Reviewer(3, "user3", false, 7, null)
                 )

--- a/app/src/test/java/com/appunite/loudius/ui/reviewers/ReviewersViewModelTest.kt
+++ b/app/src/test/java/com/appunite/loudius/ui/reviewers/ReviewersViewModelTest.kt
@@ -84,7 +84,7 @@ class ReviewersViewModelTest {
 
             expectThat(viewModel.state.data).isA<Data.Success>().and {
                 get(Data.Success::reviewers).containsExactly(
-                    // Reviewer(1, "user1", true, 7, 5),
+                    Reviewer(1, "user1", true, 7, 5),
                     Reviewer(2, "user2", false, 7, null),
                     Reviewer(3, "user3", false, 7, null)
                 )


### PR DESCRIPTION
# Pull-Request
## Description

### Why?
<!-- Describe why the change is introduced -->
We want to be aware of any failed job on the develop and main branches.

### What?
<!-- Add here short description what has changed -->
Added relevant condition to the Include Slack Notification step.

## Links to related issues
<!--- 
Add links to related tickets
-->
- Fixes [LD-142](https://loudius.atlassian.net/browse/LD-142)


## Demo
<!--- 
Screenshots or video that presents the feature or fix
-->
![Screenshot 2024-02-13 at 15 14 32](https://github.com/appunite/Loudius/assets/72873966/839be009-3d0e-4df3-8129-94e6c9ec7f27)


## How to test
<!--
Add a description that will help reviewer check if given change works as expected
-->
* **Step 1**: Add "exit 1" to any step in one of the job which is mentioned in needs context in test-results job. Example:
```diff
name: Run tests on Firebase Test Lab
  run: |-
    gcloud firebase test android run \
      --app="app/build/outputs/apk/debug/app-debug.apk" \
      --test="app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk" \
      --device="model=Pixel2.arm,version=33,locale=en,orientation=portrait" \
      --type=instrumentation \
      --use-orchestrator \
      --test-runner-class="com.appunite.loudius.util.InstrumentationTestRunner" \
      --timeout="20m" \
      --results-dir="${{ steps.generate-dir.outputs.results_dir }}" \
      --results-bucket="${{ steps.generate-dir.outputs.bucket }}" \
      --environment-variables "clearPackageData=true,coverage=true,coverageFilePath=/sdcard/Download/" \
      --directories-to-pull /sdcard/Download
+    exit 1
```
* **Expected**: After test-results job finished, you should be able to see relevant message on loudius-internal slack channel.

## Documentation
- Link to github actions docs: https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context

## Checklist
<!--- 
All those checkboxes should be marked before submitting the PR
-->

~- [ ] Functionality is covered by unit tests~
~- [ ] Functionality is covered by integration tests~
- [x] I've updated PR description with relevant information
- [x] I've done self code review
- [x] I've manually tested if the code and app works
